### PR TITLE
fix: Preview plugin tests

### DIFF
--- a/src/extension/app/components/plugin/plugin-action-bar.js
+++ b/src/extension/app/components/plugin/plugin-action-bar.js
@@ -71,8 +71,19 @@ export class PluginActionBar extends MobxLitElement {
       `;
     }
 
+    let disabled = false;
+    const isEnabled = plugin.button && plugin.button.isEnabled;
+    if (typeof isEnabled === 'function' && !isEnabled(appStore)) {
+      disabled = true;
+    }
+
     return html`
-      <sp-action-button class=${plugin.id} quiet @click=${(evt) => this.onPluginButtonClick(evt, plugin)}>
+      <sp-action-button 
+        class=${plugin.id} 
+        .disabled=${disabled} 
+        quiet 
+        @click=${(evt) => this.onPluginButtonClick(evt, plugin)}
+      >
           ${plugin.button.text}
       </sp-action-button>
     `;

--- a/src/extension/app/plugins/preview/preview.js
+++ b/src/extension/app/plugins/preview/preview.js
@@ -49,6 +49,7 @@ export function createPreviewPlugin(appStore) {
             && status.edit.sourceLocation.startsWith('onedrive:')
             && !location.pathname.startsWith('/:x:/')) {
           // show ctrl/cmd + s hint on onedrive docs
+          // istanbul ignore next
           const mac = navigator.platform.toLowerCase().includes('mac') ? '_mac' : '';
           appStore.showToast(appStore.i18n(`preview_onedrive${mac}`));
         } else if (status.edit.sourceLocation?.startsWith('gdrive:')) {
@@ -86,13 +87,13 @@ export function createPreviewPlugin(appStore) {
             previewPath: status.webPath,
             previewTimestamp: Date.now(),
           }));
-          window.location.reload();
+          appStore.reloadPage();
         } else {
           appStore.updatePreview();
         }
       },
-      isEnabled: (sidekick) => sidekick.isAuthorized('preview', 'write')
-          && sidekick.status.webPath,
+      isEnabled: (store) => store.isAuthorized('preview', 'write')
+          && store.status.webPath,
     },
     callback: () => {
       const { previewPath, previewTimestamp } = JSON
@@ -103,6 +104,7 @@ export function createPreviewPlugin(appStore) {
         appStore.showWait();
         appStore.sidekick.addEventListener('statusfetched', async () => {
           const { status } = appStore;
+          /* istanbul ignore else  */
           if (status.webPath === previewPath && appStore.isAuthorized('preview', 'write')) {
             // update preview and remove preview request from session storage
             appStore.updatePreview();

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -471,6 +471,13 @@ export class AppStore {
   }
 
   /**
+   * Reloads the current page. Abstracted for testing.
+   */
+  reloadPage() {
+    window.location.reload();
+  }
+
+  /**
    * Fires an event with the given name.
    * @param {string} name The name of the event
    * @param {Object} data The data to pass to event listeners (optional)

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -474,6 +474,7 @@ export class AppStore {
    * Reloads the current page. Abstracted for testing.
    */
   reloadPage() {
+    // istanbul ignore next
     window.location.reload();
   }
 

--- a/test/wtr/aem-config-picker.test.js
+++ b/test/wtr/aem-config-picker.test.js
@@ -51,7 +51,7 @@ describe('AEM Config Picker', () => {
     configPicker.addEventListener('configselected', configSelectedSpy);
 
     const configButton = configButtons[0];
-    configButton.dispatchEvent(new Event('click'));
+    configButton.click();
 
     expect(configSelectedSpy).to.have.been.calledOnce;
     expect(configSelectedSpy.args[0][0].detail.config).to.deep.equal(matchingConfigs[0]);

--- a/test/wtr/app/components/modal/modal.test.js
+++ b/test/wtr/app/components/modal/modal.test.js
@@ -94,7 +94,7 @@ describe('Modals', () => {
 
     const okButton = recursiveQuery(dialogView, 'sp-button');
     expect(okButton).to.exist;
-    okButton.dispatchEvent(new Event('click'));
+    okButton.click();
 
     await aTimeout(100);
     expect(recursiveQuery(modal, 'dialog-view')).to.be.undefined;

--- a/test/wtr/app/components/plugin/env-switcher.test.js
+++ b/test/wtr/app/components/plugin/env-switcher.test.js
@@ -61,12 +61,12 @@ describe('Environment Switcher', () => {
       const picker = recursiveQuery(envPlugin, 'action-bar-picker');
       const button = recursiveQuery(picker, '#button');
 
-      button.dispatchEvent(new Event('click'));
+      button.click();
 
       await waitUntil(() => recursiveQuery(picker, 'sp-popover'));
 
       const liveButton = recursiveQuery(picker, 'sp-menu-item.env-live');
-      liveButton.dispatchEvent(new Event('click'));
+      liveButton.click();
 
       picker.value = 'live';
       picker.dispatchEvent(new Event('change'));

--- a/test/wtr/app/components/plugin/palette-container.test.js
+++ b/test/wtr/app/components/plugin/palette-container.test.js
@@ -72,7 +72,7 @@ describe('Palette container', () => {
     const paletteContainer = recursiveQuery(sidekick, 'palette-container');
     const paletteDialog = recursiveQuery(sidekick, 'palette-dialog');
     const closeButton = recursiveQuery(paletteDialog, 'sp-close-button');
-    closeButton.dispatchEvent(new Event('click'));
+    closeButton.click();
 
     await waitUntil(() => paletteContainer.plugin === undefined);
 

--- a/test/wtr/app/components/plugin/palette-container.test.js
+++ b/test/wtr/app/components/plugin/palette-container.test.js
@@ -19,7 +19,7 @@ import { AEMSidekick } from '../../../../../src/extension/app/aem-sidekick.js';
 import { mockFetchEnglishMessagesSuccess } from '../../../mocks/i18n.js';
 import { defaultSidekickConfig } from '../../../fixtures/sidekick-config.js';
 import {
-  mockSharepointEditorFetchStatusSuccess,
+  mockSharepointEditorDocFetchStatusSuccess,
   mockFetchConfigWithPluginsJSONSuccess,
 } from '../../../mocks/helix-admin.js';
 import '../../../../../src/extension/index.js';
@@ -63,7 +63,7 @@ describe('Palette container', () => {
   }
 
   it('closes palette plugin via close button', async () => {
-    mockSharepointEditorFetchStatusSuccess();
+    mockSharepointEditorDocFetchStatusSuccess();
     mockFetchConfigWithPluginsJSONSuccess();
     mockEditorAdminEnvironment(document, 'editor');
 
@@ -80,7 +80,7 @@ describe('Palette container', () => {
   });
 
   it('closes palette plugin via esc key', async () => {
-    mockSharepointEditorFetchStatusSuccess();
+    mockSharepointEditorDocFetchStatusSuccess();
     mockFetchConfigWithPluginsJSONSuccess();
     mockEditorAdminEnvironment(document, 'editor');
 
@@ -99,7 +99,7 @@ describe('Palette container', () => {
   });
 
   it('palette renders titleI18n', async () => {
-    mockSharepointEditorFetchStatusSuccess();
+    mockSharepointEditorDocFetchStatusSuccess();
     mockFetchConfigWithPluginsJSONSuccess();
     mockEditorAdminEnvironment(document, 'editor');
 

--- a/test/wtr/app/components/plugin/plugin-action-bar.test.js
+++ b/test/wtr/app/components/plugin/plugin-action-bar.test.js
@@ -268,7 +268,7 @@ describe('Plugin action bar', () => {
       expectPluginCount(2);
 
       const publishButton = recursiveQuery(sidekick, '.publish');
-      publishButton.dispatchEvent(new Event('click'));
+      publishButton.click();
 
       expect(actionSpy.calledOnce).to.be.true;
 
@@ -327,7 +327,7 @@ describe('Plugin action bar', () => {
       expectPluginCount(5);
 
       const libraryPlugin = recursiveQuery(sidekick, '.library');
-      libraryPlugin.dispatchEvent(new Event('click'));
+      libraryPlugin.click();
 
       expect(openStub.calledOnce).to.be.true;
       expect(pluginUsedEventSpy.calledOnce).to.be.true;

--- a/test/wtr/app/components/plugin/plugin-action-bar.test.js
+++ b/test/wtr/app/components/plugin/plugin-action-bar.test.js
@@ -22,7 +22,7 @@ import { mockFetchEnglishMessagesSuccess } from '../../../mocks/i18n.js';
 import { defaultSidekickConfig } from '../../../fixtures/sidekick-config.js';
 import {
   mockSharepointDirectoryFetchStatusSuccess,
-  mockSharepointEditorFetchStatusSuccess,
+  mockSharepointEditorDocFetchStatusSuccess,
   mockFetchConfigJSONNotFound,
   mockFetchConfigWithPluginsJSONSuccess,
   mockFetchConfigWithoutPluginsJSONSuccess,
@@ -103,7 +103,7 @@ describe('Plugin action bar', () => {
     it('editor - w/custom plugins', async () => {
       mockFetchStatusSuccess();
       mockFetchConfigWithPluginsJSONSuccess();
-      mockSharepointEditorFetchStatusSuccess();
+      mockSharepointEditorDocFetchStatusSuccess();
       mockEditorAdminEnvironment(document, 'editor');
 
       sidekick = new AEMSidekick(defaultSidekickConfig);
@@ -180,7 +180,7 @@ describe('Plugin action bar', () => {
     });
 
     it('isEditor', async () => {
-      mockSharepointEditorFetchStatusSuccess();
+      mockSharepointEditorDocFetchStatusSuccess();
       mockFetchConfigJSONNotFound();
       mockEditorAdminEnvironment(document, 'editor');
 
@@ -200,7 +200,7 @@ describe('Plugin action bar', () => {
     });
 
     it('isEditor - custom config with prod host', async () => {
-      mockSharepointEditorFetchStatusSuccess();
+      mockSharepointEditorDocFetchStatusSuccess();
       mockFetchConfigWithoutPluginsJSONSuccess();
       mockEditorAdminEnvironment(document, 'editor');
 
@@ -276,7 +276,7 @@ describe('Plugin action bar', () => {
     });
 
     it.skip('isAdmin - loads correct plugins', async () => {
-      mockSharepointEditorFetchStatusSuccess();
+      mockSharepointEditorDocFetchStatusSuccess();
       mockFetchConfigJSONNotFound();
       mockEditorAdminEnvironment(document, 'admin');
 
@@ -288,7 +288,7 @@ describe('Plugin action bar', () => {
     });
 
     it('custom container plugin', async () => {
-      mockSharepointEditorFetchStatusSuccess();
+      mockSharepointEditorDocFetchStatusSuccess();
       mockSharepointDirectoryFetchStatusSuccess();
       mockFetchConfigWithPluginsJSONSuccess();
       mockEditorAdminEnvironment(document, 'editor');
@@ -309,7 +309,7 @@ describe('Plugin action bar', () => {
     });
 
     it('clicks custom plugin', async () => {
-      mockSharepointEditorFetchStatusSuccess();
+      mockSharepointEditorDocFetchStatusSuccess();
       mockSharepointDirectoryFetchStatusSuccess();
       mockFetchConfigWithPluginsJSONSuccess();
       mockEditorAdminEnvironment(document, 'editor');

--- a/test/wtr/app/components/toast/toast.test.js
+++ b/test/wtr/app/components/toast/toast.test.js
@@ -54,7 +54,7 @@ describe('Toasts', () => {
 
     const closeButton = recursiveQuery(toast, 'sp-close-button');
     expect(closeButton).to.exist;
-    closeButton.dispatchEvent(new Event('click'));
+    closeButton.click();
 
     await aTimeout(1);
     expect(recursiveQuery(ToastContainer, 'sp-toast')).to.be.undefined;

--- a/test/wtr/app/plugins/preview/preview.test.js
+++ b/test/wtr/app/plugins/preview/preview.test.js
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-disable no-unused-expressions, import/no-extraneous-dependencies */
+
+// @ts-ignore
+import fetchMock from 'fetch-mock/esm/client.js';
+import sinon from 'sinon';
+import { expect, waitUntil } from '@open-wc/testing';
+import { recursiveQuery } from '../../../test-utils.js';
+import chromeMock from '../../../mocks/chrome.js';
+import { AEMSidekick } from '../../../../../src/extension/app/aem-sidekick.js';
+import { mockFetchEnglishMessagesSuccess } from '../../../mocks/i18n.js';
+import { defaultSidekickConfig } from '../../../fixtures/sidekick-config.js';
+import {
+  mockSharepointEditorDocFetchStatusSuccess,
+  mockFetchConfigJSONNotFound,
+  mockGdriveEditorFetchStatusSuccess,
+  mockSharepointEditorSheetFetchStatusSuccess,
+} from '../../../mocks/helix-admin.js';
+import '../../../../../src/extension/index.js';
+import { appStore } from '../../../../../src/extension/app/store/app.js';
+import { HelixMockContentType, mockEditorAdminEnvironment, restoreEnvironment } from '../../../mocks/environment.js';
+import { EventBus } from '../../../../../src/extension/app/utils/event-bus.js';
+import { EVENTS, MODALS } from '../../../../../src/extension/app/constants.js';
+
+// @ts-ignore
+window.chrome = chromeMock;
+
+describe('Preview plugin', () => {
+  let sidekick;
+  beforeEach(async () => {
+    mockFetchEnglishMessagesSuccess();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(sidekick);
+    fetchMock.reset();
+    restoreEnvironment(document);
+  });
+
+  describe('switching between environments', () => {
+    it('previewing from sharepoint editor - docx', async () => {
+      mockSharepointEditorDocFetchStatusSuccess();
+      mockFetchConfigJSONNotFound();
+      mockEditorAdminEnvironment(document, 'editor');
+      const updatePreviewSpy = sinon.stub(appStore, 'updatePreview').resolves();
+      const tipToast = sinon.stub(appStore, 'showToast').returns();
+
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
+      expect(previewPlugin.textContent.trim()).to.equal('Preview');
+
+      previewPlugin.dispatchEvent(new Event('click'));
+
+      expect(updatePreviewSpy.calledOnce).to.be.true;
+      expect(tipToast.calledOnce).to.be.true;
+
+      updatePreviewSpy.restore();
+      tipToast.restore();
+    });
+
+    it('previewing from sharepoint editor - sheet', async () => {
+      mockSharepointEditorSheetFetchStatusSuccess();
+      mockFetchConfigJSONNotFound();
+      mockEditorAdminEnvironment(document, 'editor', HelixMockContentType.SHEET);
+      const updatePreviewSpy = sinon.stub(appStore, 'updatePreview').resolves();
+      const reloadStub = sinon.stub(appStore, 'reloadPage').returns();
+
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      // Click the preview the plugin
+      const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
+      previewPlugin.dispatchEvent(new Event('click'));
+
+      expect(reloadStub.calledOnce).to.be.true;
+
+      // Simulate a reload
+      document.body.removeChild(sidekick);
+
+      // Make sure the hlx-sk-preview flag is set
+      expect(window.sessionStorage.getItem('hlx-sk-preview')).to.not.be.null;
+
+      // Reset the environment
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      expect(updatePreviewSpy.calledOnce).to.be.true;
+
+      // Make sure the hlx-sk-preview flag is unset
+      expect(window.sessionStorage.getItem('hlx-sk-preview')).to.be.null;
+
+      updatePreviewSpy.restore();
+      reloadStub.restore();
+    });
+
+    it('previewing from gdrive editor - doc', async () => {
+      mockGdriveEditorFetchStatusSuccess();
+      mockFetchConfigJSONNotFound();
+      mockEditorAdminEnvironment(document, 'editor', 'doc', 'gdrive');
+      const updatePreviewSpy = sinon.stub(appStore, 'updatePreview').resolves();
+
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
+
+      previewPlugin.dispatchEvent(new Event('click'));
+
+      expect(updatePreviewSpy.calledOnce).to.be.true;
+
+      updatePreviewSpy.restore();
+    });
+
+    it('previewing from gdrive editor - not a valid content type', async () => {
+      mockGdriveEditorFetchStatusSuccess();
+      mockFetchConfigJSONNotFound();
+      mockEditorAdminEnvironment(document, 'editor', 'doc', 'gdrive');
+
+      const modalSpy = sinon.spy();
+      EventBus.instance.addEventListener(EVENTS.OPEN_MODAL, modalSpy);
+
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      appStore.status.edit.contentType = 'invalid';
+
+      const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
+
+      previewPlugin.dispatchEvent(new Event('click'));
+
+      expect(modalSpy.calledOnce).to.be.true;
+      expect(modalSpy.args[0][0].detail.type).to.equal(MODALS.ERROR);
+    });
+
+    it('previewing from gdrive editor - not a gdoc type', async () => {
+      mockGdriveEditorFetchStatusSuccess();
+      mockFetchConfigJSONNotFound();
+      mockEditorAdminEnvironment(document, 'editor', 'doc', 'gdrive');
+
+      const modalSpy = sinon.spy();
+      EventBus.instance.addEventListener(EVENTS.OPEN_MODAL, modalSpy);
+
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      appStore.status.edit.contentType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+      const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
+
+      previewPlugin.dispatchEvent(new Event('click'));
+
+      expect(modalSpy.calledOnce).to.be.true;
+      expect(modalSpy.args[0][0].detail.type).to.equal(MODALS.ERROR);
+    });
+
+    it('previewing from gdrive editor - not a gsheet type', async () => {
+      mockGdriveEditorFetchStatusSuccess();
+      mockFetchConfigJSONNotFound();
+      mockEditorAdminEnvironment(document, 'editor', 'doc', 'gdrive');
+
+      const modalSpy = sinon.spy();
+      EventBus.instance.addEventListener(EVENTS.OPEN_MODAL, modalSpy);
+
+      sidekick = new AEMSidekick(defaultSidekickConfig);
+      document.body.appendChild(sidekick);
+
+      await waitUntil(() => recursiveQuery(sidekick, 'action-bar-picker'));
+
+      appStore.status.edit.contentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+      const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
+
+      previewPlugin.dispatchEvent(new Event('click'));
+
+      expect(modalSpy.calledOnce).to.be.true;
+      expect(modalSpy.args[0][0].detail.type).to.equal(MODALS.ERROR);
+    });
+  });
+});

--- a/test/wtr/app/plugins/preview/preview.test.js
+++ b/test/wtr/app/plugins/preview/preview.test.js
@@ -63,7 +63,7 @@ describe('Preview plugin', () => {
       const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
       expect(previewPlugin.textContent.trim()).to.equal('Preview');
 
-      previewPlugin.dispatchEvent(new Event('click'));
+      previewPlugin.click();
 
       expect(updatePreviewSpy.calledOnce).to.be.true;
       expect(tipToast.calledOnce).to.be.true;
@@ -86,7 +86,7 @@ describe('Preview plugin', () => {
 
       // Click the preview the plugin
       const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
-      previewPlugin.dispatchEvent(new Event('click'));
+      previewPlugin.click();
 
       expect(reloadStub.calledOnce).to.be.true;
 
@@ -124,7 +124,7 @@ describe('Preview plugin', () => {
 
       const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
 
-      previewPlugin.dispatchEvent(new Event('click'));
+      previewPlugin.click();
 
       expect(updatePreviewSpy.calledOnce).to.be.true;
 
@@ -148,7 +148,7 @@ describe('Preview plugin', () => {
 
       const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
 
-      previewPlugin.dispatchEvent(new Event('click'));
+      previewPlugin.click();
 
       expect(modalSpy.calledOnce).to.be.true;
       expect(modalSpy.args[0][0].detail.type).to.equal(MODALS.ERROR);
@@ -171,7 +171,7 @@ describe('Preview plugin', () => {
 
       const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
 
-      previewPlugin.dispatchEvent(new Event('click'));
+      previewPlugin.click();
 
       expect(modalSpy.calledOnce).to.be.true;
       expect(modalSpy.args[0][0].detail.type).to.equal(MODALS.ERROR);
@@ -194,7 +194,7 @@ describe('Preview plugin', () => {
 
       const previewPlugin = recursiveQuery(sidekick, '.edit-preview');
 
-      previewPlugin.dispatchEvent(new Event('click'));
+      previewPlugin.click();
 
       expect(modalSpy.calledOnce).to.be.true;
       expect(modalSpy.args[0][0].detail.type).to.equal(MODALS.ERROR);

--- a/test/wtr/app/store/app.test.js
+++ b/test/wtr/app/store/app.test.js
@@ -20,7 +20,7 @@ import chromeMock from '../../mocks/chrome.js';
 import {
   mockFetchConfigJSONNotFound,
   mockFetchConfigWithPluginsJSONSuccess,
-  mockFetchStatusEditURLSuccess,
+  mockGdriveFetchStatusEditURLSuccess,
   mockFetchStatusNotFound,
   mockFetchStatusServerError,
   mockFetchStatusSuccess,
@@ -293,7 +293,7 @@ describe('Test App Store', () => {
     });
 
     it('success - editor', async () => {
-      mockFetchStatusEditURLSuccess();
+      mockGdriveFetchStatusEditURLSuccess();
       sinon.stub(appStore, 'isEditor').returns(true);
       await appStore.loadContext(sidekickElement, defaultSidekickConfig);
       await appStore.fetchStatus();

--- a/test/wtr/app/store/app.test.js
+++ b/test/wtr/app/store/app.test.js
@@ -384,4 +384,245 @@ describe('Test App Store', () => {
       });
     });
   });
+
+  describe('update', async () => {
+    let sandbox;
+    let fakeFetch;
+    let instance;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      fakeFetch = sandbox.stub(window, 'fetch');
+      instance = appStore;
+
+      // Mock other functions
+      sandbox.stub(instance, 'isContent');
+      sandbox.stub(instance, 'isEditor');
+      sandbox.stub(instance, 'isPreview');
+      sandbox.stub(instance, 'isDev');
+      sandbox.stub(instance, 'fireEvent');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should handle successful update for content w/path', async () => {
+      instance.isContent.returns(true);
+
+      const headers = new Headers();
+
+      fakeFetch.resolves({
+        ok: true, status: 200, headers, json: () => Promise.resolve({ webPath: '/somepath' }),
+      });
+
+      const response = await instance.update('/ignored-path');
+
+      expect(response).to.deep.equal({
+        ok: true,
+        status: 200,
+        error: '',
+        path: '/somepath',
+      });
+      sinon.assert.calledWith(instance.fireEvent, 'updated', '/somepath');
+      sinon.assert.calledWith(instance.fireEvent, 'previewed', '/somepath');
+    });
+
+    it('should handle successful update for content wo/path', async () => {
+      instance.isContent.returns(true);
+
+      const headers = new Headers();
+
+      fakeFetch.resolves({
+        ok: true, status: 200, headers, json: () => Promise.resolve({ webPath: '/somepath' }),
+      });
+
+      const response = await instance.update();
+
+      expect(response).to.deep.equal({
+        ok: true,
+        status: 200,
+        error: '',
+        path: '/somepath',
+      });
+      sinon.assert.calledWith(instance.fireEvent, 'updated', '/somepath');
+      sinon.assert.calledWith(instance.fireEvent, 'previewed', '/somepath');
+    });
+
+    it('should bust client cache', async () => {
+      instance.isEditor.returns(true);
+
+      instance.siteStore.innerHost = 'main--aem-boilerplate--adobe.hlx.page';
+
+      const headers = new Headers();
+
+      fakeFetch.resolves({
+        ok: true, status: 200, headers, json: () => Promise.resolve({ webPath: '/somepath' }),
+      });
+
+      const response = await instance.update('/testpath');
+
+      expect(response).to.deep.equal({
+        ok: true,
+        status: 200,
+        error: '',
+        path: '/somepath',
+      });
+
+      sinon.assert.calledWith(instance.fireEvent, 'updated', '/somepath');
+      expect(fakeFetch.args[1][0]).to.equal('https://main--aem-boilerplate--adobe.hlx.page/testpath');
+      expect(fakeFetch.args[1][1]).to.deep.equal({ cache: 'reload', mode: 'no-cors' });
+    });
+
+    it('should handle successful update for code', async () => {
+      instance.isContent.returns(false);
+
+      const headers = new Headers();
+
+      fakeFetch.resolves({
+        ok: true, status: 200, headers, json: () => Promise.resolve({ webPath: '/somepath' }),
+      });
+
+      const response = await instance.update('/ignored-path');
+
+      expect(response).to.deep.equal({
+        ok: true,
+        status: 200,
+        error: '',
+        path: '/somepath',
+      });
+      sinon.assert.calledWith(instance.fireEvent, 'updated', '/somepath');
+    });
+
+    it('should handle fetch error', async () => {
+      fakeFetch.rejects(new Error('Network failure'));
+
+      const response = await instance.update('/testpath');
+
+      expect(response).to.deep.equal({
+        ok: false,
+        status: 0,
+        error: '',
+        path: '/testpath',
+      });
+    });
+
+    it('should handle non-OK response from fetch', async () => {
+      fakeFetch.resolves({ ok: false, status: 404, headers: { get: () => 'Not Found' } });
+
+      const response = await instance.update('/testpath');
+
+      expect(response).to.deep.equal({
+        ok: false,
+        status: 404,
+        error: 'Not Found',
+        path: '/testpath',
+      });
+    });
+  });
+
+  describe('updatePreview', () => {
+    let instance;
+    let updateStub;
+    let showWaitStub;
+    let hideWaitStub;
+    let fetchStatusStub;
+    let switchEnvStub;
+    let showToastStub;
+    let updatePreviewSpy;
+    let addEventListenerSpy;
+    let dispatchEventSpy;
+
+    beforeEach(() => {
+      instance = appStore;
+      instance.sidekick = document.createElement('div');
+      updateStub = sinon.stub(instance, 'update');
+      showWaitStub = sinon.stub(instance, 'showWait');
+      hideWaitStub = sinon.stub(instance, 'hideWait');
+      fetchStatusStub = sinon.stub(instance, 'fetchStatus');
+      switchEnvStub = sinon.stub(instance, 'switchEnv');
+      showToastStub = sinon.stub(instance, 'showToast');
+      updatePreviewSpy = sinon.spy(instance, 'updatePreview');
+      addEventListenerSpy = sinon.spy(instance.sidekick, 'addEventListener');
+      dispatchEventSpy = sinon.spy(EventBus.instance, 'dispatchEvent');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should show wait, update, and handle success response', async () => {
+      updateStub.resolves({ ok: true });
+      instance.status = { webPath: '/somepath' };
+
+      await instance.updatePreview(false);
+
+      expect(showWaitStub.called).is.true;
+      expect(hideWaitStub.called).is.true;
+      expect(switchEnvStub.calledWith('preview')).is.true;
+    });
+
+    // Test when resp is not ok, ranBefore is false
+    it('should handle failure response without ranBefore', async () => {
+      updateStub.resolves({ ok: false });
+      instance.status = { webPath: '/somepath' };
+
+      await instance.updatePreview(false);
+
+      expect(showWaitStub.called).is.true;
+      expect(addEventListenerSpy.called).is.true;
+      expect(fetchStatusStub.called).is.true;
+
+      instance.sidekick.dispatchEvent(new CustomEvent('statusfetched', { detail: { status: { webPath: '/somepath' } } }));
+      await waitUntil(() => updatePreviewSpy.calledTwice);
+    });
+
+    // Test when resp is not ok, ranBefore is true, status.webPath
+    // starts with /.helix/, resp has error
+    it('should handle failure with specific path and error', async () => {
+      updateStub.resolves({ ok: false, error: 'Error message' });
+      instance.status = { webPath: '/.helix/some-path' };
+
+      await instance.updatePreview(true);
+
+      expect(showWaitStub.called).is.true;
+      expect(dispatchEventSpy.calledWith(sinon.match.has('type', EVENTS.OPEN_MODAL))).is.true;
+    });
+
+    // Test when resp is not ok, ranBefore is true, status.webPath
+    // does not start with /.helix/, or resp has no error
+    it('should handle generic failure', async () => {
+      updateStub.resolves({ ok: false });
+      instance.status = { webPath: '/not-helix/' };
+
+      await instance.updatePreview(true);
+
+      expect(showWaitStub.called).is.true;
+      expect(dispatchEventSpy.calledWith(sinon.match.has('type', EVENTS.OPEN_MODAL))).is.true;
+    });
+
+    // Test when resp is ok and status.webPath starts with /.helix/
+    it('should handle success with specific path', async () => {
+      updateStub.resolves({ ok: true });
+      instance.status = { webPath: '/.helix/some-path' };
+
+      await instance.updatePreview(false);
+
+      expect(showWaitStub.called).is.true;
+      expect(hideWaitStub.called).is.false;
+      expect(showToastStub.calledWith(sinon.match.string, 'positive')).is.true;
+    });
+
+    // Test when resp is ok and status.webPath does not start with /.helix/
+    it('should handle generic success', async () => {
+      updateStub.resolves({ ok: true });
+      instance.status = { webPath: '/not-helix/' };
+
+      await instance.updatePreview(false);
+
+      expect(showWaitStub.called).is.true;
+      expect(hideWaitStub.called).is.true;
+      expect(switchEnvStub.calledWith('preview')).is.true;
+    });
+  });
 });

--- a/test/wtr/fixtures/helix-admin.js
+++ b/test/wtr/fixtures/helix-admin.js
@@ -108,7 +108,60 @@ export const defaultConfigJSONWithPlugins = {
 /**
  * status request stubs
  */
-export const defaultStatusResponse = {
+export const defaultSharepointStatusResponse = {
+  webPath: '/',
+  resourcePath: '/index.md',
+  live: {
+    url: 'https://main--aem-boilerplate--adobe.hlx.live/',
+    status: 200,
+    contentBusId: 'helix-content-bus/content-bus-id/live/index.md',
+    contentType: 'text/plain; charset=utf-8',
+    lastModified: 'Tue, 19 Dec 2023 15:42:45 GMT',
+    sourceLocation: 'onedrive:/drives/drive-id/items/item-id',
+    sourceLastModified: 'Wed, 01 Nov 2023 17:22:52 GMT',
+    permissions: [
+      'read',
+      'write',
+    ],
+  },
+  preview: {
+    url: 'https://main--aem-boilerplate--adobe.hlx.page/',
+    status: 200,
+    contentBusId: 'helix-content-bus/content-bus-id/preview/index.md',
+    contentType: 'text/plain; charset=utf-8',
+    lastModified: 'Tue, 19 Dec 2023 15:42:34 GMT',
+    sourceLocation: 'onedrive:/drives/drive-id/items/item-id',
+    sourceLastModified: 'Wed, 01 Nov 2023 17:22:52 GMT',
+    permissions: [
+      'read',
+      'write',
+    ],
+  },
+  edit: {
+    url: 'https://adobe-my.sharepoint.com/:w:/r/personal/user_adobe_com/_layouts/15/Doc.aspx?sourcedoc={89B9F732-7067-458B-BF05-C64013503F33}',
+    name: 'index',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    lastModified: 'Wed, 29 Dec 2023 17:22:52 GMT',
+    sourceLocation: 'onedrive:/drives/drive-id/items/item-id',
+    status: 200,
+  },
+  code: {
+    status: 400,
+    permissions: [
+      'delete',
+      'read',
+      'write',
+    ],
+  },
+  links: {
+    status: 'https://admin.hlx.page/status/adobe/aem-boilerplate/main/',
+    preview: 'https://admin.hlx.page/preview/adobe/aem-boilerplate/main/',
+    live: 'https://admin.hlx.page/live/adobe/aem-boilerplate/main/',
+    code: 'https://admin.hlx.page/code/adobe/aem-boilerplate/main/',
+  },
+};
+
+export const defaultGdriveStatusResponse = {
   webPath: '/',
   resourcePath: '/index.md',
   live: {
@@ -169,7 +222,7 @@ export const defaultStatusResponse = {
 };
 
 export const statusResponseWithProfile = {
-  ...defaultStatusResponse,
+  ...defaultGdriveStatusResponse,
   profile: {
     iss: 'https://accounts.google.com',
     aud: 'user-id.apps.googleusercontent.com',
@@ -189,7 +242,7 @@ export const statusResponseWithProfile = {
   },
 };
 
-export const defaultDirectoryStatusResponse = {
+export const defaultDirectorySharepointStatusResponse = {
   webPath: '/',
   resourcePath: '/',
   live: {
@@ -212,6 +265,52 @@ export const defaultDirectoryStatusResponse = {
   },
   edit: {
     url: 'https://adobe-my.sharepoint.com/personal/user_adobe_com/_layouts/15/onedrive.aspx?id=%2Fpersonal%5Fadobe%5Fcom%2FDocuments%2Faem%2Dboilerplate&view=0',
+    name: 'aem-boilerplate',
+    contentType: 'application/folder',
+    folders: [],
+    lastModified: 'Mon, 14 Feb 2022 16:39:24 GMT',
+    sourceLocation: 'gdrive:drive-id',
+    status: 200,
+  },
+  code: {
+    status: 400,
+    permissions: [
+      'delete',
+      'read',
+      'write',
+    ],
+  },
+  links: {
+    status: 'https://admin.hlx.page/status/adobe/aem-boilerplate/main/',
+    preview: 'https://admin.hlx.page/preview/adobe/aem-boilerplate/main/',
+    live: 'https://admin.hlx.page/live/adobe/aem-boilerplate/main/',
+    code: 'https://admin.hlx.page/code/adobe/aem-boilerplate/main/',
+  },
+};
+
+export const defaultDirectoryGdriveStatusResponse = {
+  webPath: '/',
+  resourcePath: '/',
+  live: {
+    url: 'https://main--aem-boilerplate--adobe.hlx.live/',
+    status: 404,
+    contentBusId: 'helix-content-bus/content-bus-id/live/',
+    permissions: [
+      'read',
+      'write',
+    ],
+  },
+  preview: {
+    url: 'https://main--aem-boilerplate--adobe.hlx.page/',
+    status: 404,
+    contentBusId: 'helix-content-bus/content-bus-id/preview/',
+    permissions: [
+      'read',
+      'write',
+    ],
+  },
+  edit: {
+    url: 'https://drive.google.com/drive/u/1/folders/folder-id',
     name: 'aem-boilerplate',
     contentType: 'application/folder',
     folders: [],

--- a/test/wtr/mocks/environment.js
+++ b/test/wtr/mocks/environment.js
@@ -21,7 +21,7 @@ let stubs = [];
  * Mock content types
  * @enum {string}
  */
-const HelixMockContentType = {
+export const HelixMockContentType = {
   DOC: 'doc',
   SHEET: 'sheet',
   IMAGE: 'image',

--- a/test/wtr/mocks/helix-admin.js
+++ b/test/wtr/mocks/helix-admin.js
@@ -17,8 +17,9 @@ import fetchMock from 'fetch-mock/esm/client.js';
 import {
   defaultConfigJSON,
   defaultConfigJSONWithPlugins,
-  defaultStatusResponse,
-  defaultDirectoryStatusResponse,
+  defaultSharepointStatusResponse,
+  defaultGdriveStatusResponse,
+  defaultDirectorySharepointStatusResponse,
 } from '../fixtures/helix-admin.js';
 import {
   getDefaultEditorEnviromentLocations,
@@ -55,19 +56,25 @@ export const mockFetchLocalConfigJSONSuccess = (overrides = {}) => fetchMock.get
 });
 
 export const defaultStatusUrl = 'https://admin.hlx.page/status/adobe/aem-boilerplate/main/?editUrl=auto';
-export const mockFetchStatusSuccess = (overrides = {}) => fetchMock.get(defaultStatusUrl, {
+export const mockFetchStatusSuccess = (overrides = {}, contentSource = 'sharepoint') => fetchMock.get(defaultStatusUrl, {
+  status: 200,
+  body: contentSource === 'sharepoint' ? { ...defaultSharepointStatusResponse, ...overrides } : { ...defaultGdriveStatusResponse, ...overrides },
+}, { overwriteRoutes: true });
+
+export const sharepointEditorDocStatusUrl = `https://admin.hlx.page/status/adobe/aem-boilerplate/main?editUrl=${encodeURIComponent(getDefaultEditorEnviromentLocations('sharepoint', 'doc'))}`;
+export const mockSharepointEditorDocFetchStatusSuccess = (overrides = {}) => fetchMock.get(sharepointEditorDocStatusUrl, {
   status: 200,
   body: {
-    ...defaultStatusResponse,
+    ...defaultSharepointStatusResponse,
     ...overrides,
   },
 }, { overwriteRoutes: true });
 
-export const sharepointEditorStatusUrl = `https://admin.hlx.page/status/adobe/aem-boilerplate/main?editUrl=${encodeURIComponent(getDefaultEditorEnviromentLocations('sharepoint', 'doc'))}`;
-export const mockSharepointEditorFetchStatusSuccess = (overrides = {}) => fetchMock.get(sharepointEditorStatusUrl, {
+export const sharepointEditorSheetStatusUrl = `https://admin.hlx.page/status/adobe/aem-boilerplate/main?editUrl=${encodeURIComponent(getDefaultEditorEnviromentLocations('sharepoint', 'sheet'))}`;
+export const mockSharepointEditorSheetFetchStatusSuccess = (overrides = {}) => fetchMock.get(sharepointEditorSheetStatusUrl, {
   status: 200,
   body: {
-    ...defaultStatusResponse,
+    ...defaultSharepointStatusResponse,
     ...overrides,
   },
 }, { overwriteRoutes: true });
@@ -76,7 +83,7 @@ export const gdriveEditorStatusUrl = `https://admin.hlx.page/status/adobe/aem-bo
 export const mockGdriveEditorFetchStatusSuccess = (overrides = {}) => fetchMock.get(gdriveEditorStatusUrl, {
   status: 200,
   body: {
-    ...defaultStatusResponse,
+    ...defaultGdriveStatusResponse,
     ...overrides,
   },
 }, { overwriteRoutes: true });
@@ -85,18 +92,30 @@ export const sharepointDirectoryStatusUrl = `https://admin.hlx.page/status/adobe
 export const mockSharepointDirectoryFetchStatusSuccess = (overrides = {}) => fetchMock.get(sharepointDirectoryStatusUrl, {
   status: 200,
   body: {
-    ...defaultDirectoryStatusResponse,
-    ...overrides,
+    body: {
+      ...defaultDirectorySharepointStatusResponse,
+      ...overrides,
+    },
   },
 }, { overwriteRoutes: true });
 
 export const defaultStatusEditUrl = 'glob:https://admin.hlx.page/status/adobe/aem-boilerplate/main?editUrl=*';
-export const mockFetchStatusEditURLSuccess = (overrides = {}) => fetchMock.get(defaultStatusEditUrl, {
+export const mockSharepointFetchStatusEditURLSuccess = (overrides = {}) => fetchMock.get(defaultStatusEditUrl, {
   status: 200,
   body: {
-    ...defaultStatusResponse,
+    ...defaultSharepointStatusResponse,
     ...overrides,
   },
+
+}, { overwriteRoutes: true });
+
+export const mockGdriveFetchStatusEditURLSuccess = (overrides = {}) => fetchMock.get(defaultStatusEditUrl, {
+  status: 200,
+  body: {
+    ...defaultGdriveStatusResponse,
+    ...overrides,
+  },
+
 }, { overwriteRoutes: true });
 
 export const mockFetchStatusUnauthorized = () => fetchMock.get(defaultStatusUrl, {


### PR DESCRIPTION
- Preview plugin tests
- Support disabled state in core plugins
- Abstract window.location.reload for testing
- Update test fixtures to include payloads for gdrive and sharepoint
- update and updatePreview coverage in appStore