### PR TITLE
fix: improve content source detection in environment switcher

### DIFF
--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -681,5 +681,8 @@
     },
     "deleting_state": {
       "message": "Deleting..."
+    },
+    "editor": {
+      "message": "Editor"
     }
 }

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -681,8 +681,5 @@
     },
     "deleting_state": {
       "message": "Deleting..."
-    },
-    "editor": {
-      "message": "Editor"
     }
 }

--- a/src/extension/app/components/plugin/env-switcher/env-switcher.js
+++ b/src/extension/app/components/plugin/env-switcher/env-switcher.js
@@ -133,7 +133,15 @@ export class EnvironmentSwitcher extends ConnectedElement {
     if (this.currentEnv === id) {
       attrs.disabled = '';
     }
-    const label = id === 'edit' ? this.appStore.i18n('open_in').replace('$1', this.appStore.getContentSourceLabel()) : this.envNames[id];
+
+    const contentSourceLabel = this.appStore.getContentSourceLabel();
+    if (id === 'edit' && contentSourceLabel === 'BYOM') {
+      return createTag({
+        tag: 'span',
+      });
+    }
+
+    const label = id === 'edit' ? this.appStore.i18n('open_in').replace('$1', contentSourceLabel) : this.envNames[id];
     const menuItem = createTag({
       tag: 'sp-menu-item',
       text: label,

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -536,7 +536,7 @@ export class AppStore {
 
     // No sourceLocation on preview for JSON files
     if (!sourceLocation) {
-      return 'Editor';
+      return this.i18n('editor');
     }
 
     return sourceLocation.includes('onedrive:') ? 'SharePoint' : 'Google Drive';

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -543,9 +543,10 @@ export class AppStore {
     }
 
     const { mountpoint } = this.siteStore;
-    return mountpoint.includes('.google.com')
+    const mountpointUrl = new URL(mountpoint);
+    return mountpointUrl.host.includes('.google.com')
       ? 'Google Drive'
-      : mountpoint.includes('.sharepoint.com') || mountpoint.includes('/Shared%20Documents/sites/')
+      : mountpointUrl.host.includes('.sharepoint.com') || mountpointUrl.pathname.includes('/Shared%20Documents/sites/')
         ? 'SharePoint'
         : 'BYOM';
   }

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-disable no-restricted-globals */
+/* eslint-disable no-restricted-globals, no-nested-ternary */
 
 import { observable, action } from 'mobx';
 import { createContext } from '@lit/context';
@@ -534,12 +534,20 @@ export class AppStore {
     const { preview } = this.status;
     const { sourceLocation } = preview;
 
-    // No sourceLocation on preview for JSON files
-    if (!sourceLocation) {
-      return this.i18n('editor');
+    if (sourceLocation) {
+      return sourceLocation.includes('onedrive:')
+        ? 'SharePoint'
+        : sourceLocation.includes('gdrive:')
+          ? 'Google Drive'
+          : 'BYOM';
     }
 
-    return sourceLocation.includes('onedrive:') ? 'SharePoint' : 'Google Drive';
+    const { mountpoint } = this.siteStore;
+    return mountpoint.includes('.sharepoint.com')
+      ? 'SharePoint'
+      : mountpoint.includes('.google.com')
+        ? 'Google Drive'
+        : 'BYOM';
   }
 
   /**

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -535,18 +535,18 @@ export class AppStore {
     const { sourceLocation } = preview;
 
     if (sourceLocation) {
-      return sourceLocation.includes('onedrive:')
+      return sourceLocation.startsWith('onedrive:')
         ? 'SharePoint'
-        : sourceLocation.includes('gdrive:')
+        : sourceLocation.startsWith('gdrive:')
           ? 'Google Drive'
           : 'BYOM';
     }
 
     const { mountpoint } = this.siteStore;
-    return mountpoint.includes('.sharepoint.com')
-      ? 'SharePoint'
-      : mountpoint.includes('.google.com')
-        ? 'Google Drive'
+    return mountpoint.includes('.google.com')
+      ? 'Google Drive'
+      : mountpoint.includes('.sharepoint.com') || mountpoint.includes('/Shared%20Documents/sites/')
+        ? 'SharePoint'
         : 'BYOM';
   }
 

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -532,7 +532,14 @@ export class AppStore {
    */
   getContentSourceLabel() {
     const { preview } = this.status;
-    return preview?.sourceLocation.includes('onedrive:') ? 'SharePoint' : 'Google Drive';
+    const { sourceLocation } = preview;
+
+    // No sourceLocation on preview for JSON files
+    if (!sourceLocation) {
+      return 'Editor';
+    }
+
+    return sourceLocation.includes('onedrive:') ? 'SharePoint' : 'Google Drive';
   }
 
   /**

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_title__",
-    "version": "0.0.1",
+    "version": "0.0.3",
     "author": "Adobe",
     "homepage_url": "https://www.hlx.live/tools/sidekick/",
     "default_locale": "en",
@@ -50,7 +50,7 @@
           "polyfills.min.js",
           "sp-popover.js",
           "sp-tray.js",
-          "views/json/json.html",
+          "views/json/*",
           "rum.js"
         ],
         "matches": [

--- a/test/app/components/plugin/env-switcher.test.js
+++ b/test/app/components/plugin/env-switcher.test.js
@@ -319,5 +319,32 @@ describe('Environment Switcher', () => {
       const publishButton = recursiveQuery(notificationItem, 'sp-action-button');
       expect(publishButton.hasAttribute('disabled')).to.be.true;
     }).timeout(20000);
+
+    it('viewing json file should say open in editor', async () => {
+      sidekickTest
+        .mockFetchSidekickConfigSuccess(true)
+        .mockFetchStatusSuccess(false, {
+          webPath: '/query-index.json',
+          resourcePath: '/query-index.json',
+          preview: {
+            url: 'https://main--blog--adobecom.hlx.page/query-index.json',
+            status: 200,
+            contentBusId: 'helix-content-bus/cbid/preview/query-index.json',
+            contentType: 'application/json',
+            lastModified: 'Tue, 12 Sep 2023 19:38:51 GMT',
+            permissions: [
+              'read',
+              'write',
+            ],
+          },
+        }, HelixMockContentSources.SHAREPOINT, 'https://admin.hlx.page/status/adobe/aem-boilerplate/main/placeholders.json')
+        .mockHelixEnvironment(HelixMockEnvironments.PREVIEW, HelixMockContentType.SHEET);
+
+      sidekick = sidekickTest.createSidekick();
+      await sidekickTest.awaitEnvSwitcher();
+
+      const editPlugin = recursiveQuery(sidekick, '.env-edit');
+      expect(editPlugin.textContent.trim()).to.eq('Open in Editor');
+    });
   });
 });

--- a/test/app/components/plugin/env-switcher.test.js
+++ b/test/app/components/plugin/env-switcher.test.js
@@ -320,9 +320,9 @@ describe('Environment Switcher', () => {
       expect(publishButton.hasAttribute('disabled')).to.be.true;
     }).timeout(20000);
 
-    it('viewing json file should say open in editor', async () => {
+    it('should not show edit if byom sourceLocation', async () => {
       sidekickTest
-        .mockFetchSidekickConfigSuccess(true)
+        .mockFetchSidekickConfigSuccess()
         .mockFetchStatusSuccess(false, {
           webPath: '/query-index.json',
           resourcePath: '/query-index.json',
@@ -331,6 +331,7 @@ describe('Environment Switcher', () => {
             status: 200,
             contentBusId: 'helix-content-bus/cbid/preview/query-index.json',
             contentType: 'application/json',
+            sourceLocation: 'markup:https://byom.adobeioruntime.net/api/v1/web/convert/main/index.html?wcmmode=disabled',
             lastModified: 'Tue, 12 Sep 2023 19:38:51 GMT',
             permissions: [
               'read',
@@ -344,7 +345,7 @@ describe('Environment Switcher', () => {
       await sidekickTest.awaitEnvSwitcher();
 
       const editPlugin = recursiveQuery(sidekick, '.env-edit');
-      expect(editPlugin.textContent.trim()).to.eq('Open in Editor');
+      expect(editPlugin).to.be.undefined;
     });
   });
 });

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -1561,6 +1561,12 @@ describe('Test App Store', () => {
       expect(instance.getContentSourceLabel()).to.equal('SharePoint');
     });
 
+    it('should return "SharePoint" if mountpoint does not include ".sharepoint.com" but does contain /Shared%20Documents/sites/', () => {
+      instance.siteStore = { mountpoint: 'https://example.com/Shared%20Documents/sites/aem-boilerplate' };
+      instance.status = { preview: { sourceLocation: '' } };
+      expect(instance.getContentSourceLabel()).to.equal('SharePoint');
+    });
+
     it('should return "Google Drive" if mountpoint includes ".google.com"', () => {
       instance.siteStore = { mountpoint: 'https://drive.google.com' };
       instance.status = { preview: { sourceLocation: '' } };

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -1532,4 +1532,45 @@ describe('Test App Store', () => {
       expect(instance.login.called).to.be.false;
     });
   });
+
+  describe('getContentSourceLabel', () => {
+    let instance;
+
+    beforeEach(() => {
+      instance = new AppStore();
+    });
+
+    it('should return "SharePoint" if sourceLocation includes "onedrive:"', () => {
+      instance.status = { preview: { sourceLocation: 'onedrive:example' } };
+      expect(instance.getContentSourceLabel()).to.equal('SharePoint');
+    });
+
+    it('should return "Google Drive" if sourceLocation includes "gdrive:"', () => {
+      instance.status = { preview: { sourceLocation: 'gdrive:example' } };
+      expect(instance.getContentSourceLabel()).to.equal('Google Drive');
+    });
+
+    it('should return "BYOM" if sourceLocation does not include known patterns', () => {
+      instance.status = { preview: { sourceLocation: 'dropbox:example' } };
+      expect(instance.getContentSourceLabel()).to.equal('BYOM');
+    });
+
+    it('should return "SharePoint" if mountpoint includes ".sharepoint.com"', () => {
+      instance.siteStore = { mountpoint: 'https://example.sharepoint.com' };
+      instance.status = { preview: { sourceLocation: '' } };
+      expect(instance.getContentSourceLabel()).to.equal('SharePoint');
+    });
+
+    it('should return "Google Drive" if mountpoint includes ".google.com"', () => {
+      instance.siteStore = { mountpoint: 'https://drive.google.com' };
+      instance.status = { preview: { sourceLocation: '' } };
+      expect(instance.getContentSourceLabel()).to.equal('Google Drive');
+    });
+
+    it('should return "BYOM" if mountpoint does not include known patterns', () => {
+      instance.siteStore = { mountpoint: 'https://example.com' };
+      instance.status = { preview: { sourceLocation: '' } };
+      expect(instance.getContentSourceLabel()).to.equal('BYOM');
+    });
+  });
 });


### PR DESCRIPTION
The environment switcher tells the user which content source we will switch to when hitting the edit button. This PR makes that detection more robust and also will hide the button when it's a BYOM project.

Also allow-listed more of the files required to render the json view.