### PR TITLE
fix: don't call checkTab if sidekick hidden from ui

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -21,6 +21,8 @@ import {
   checkViewDocSource,
 } from './actions.js';
 import { addAuthTokenHeaders } from './auth.js';
+import { getProjectMatches, getProjects } from './project.js';
+import { updateIcon } from './ui.js';
 
 chrome.action.onClicked.addListener(async ({ id }) => {
   // toggle the sidekick when the action is clicked
@@ -55,7 +57,9 @@ chrome.runtime.onMessageExternal.addListener(async (message, sender, sendRespons
 chrome.storage.onChanged.addListener(async (changes, storageArea) => {
   if (storageArea === 'local' && changes.display) {
     const tab = await getCurrentTab();
-    checkTab(tab.id);
+    const projects = await getProjects();
+    const matches = await getProjectMatches(projects, tab);
+    await updateIcon({ matches });
   }
 });
 

--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -54,6 +54,7 @@
     // Listen for display toggle events from application
     sidekick.addEventListener('hidden', () => {
       toggleDisplay();
+      sidekick.setAttribute('open', 'false');
     });
   }
 


### PR DESCRIPTION
If the sidekick is hidden and then opened multiple requests are being made to admin for sidekick config and status. This seemed to be caused by the call to `checkTab` I added. Instead of calling `checkTab` when the display state changes in local storage I am instead just calling updateIcon which is all I needed to do in the first place.