### PR TITLE
fix: don't drop project name from share settings

### DIFF
--- a/src/extension/project.js
+++ b/src/extension/project.js
@@ -149,7 +149,12 @@ export async function getProjectFromUrl(tab) {
   const shareSettings = getShareSettings(url);
   if (shareSettings.giturl) {
     // share url
-    return getGitHubSettings(shareSettings.giturl);
+    const ghSettings = getGitHubSettings(shareSettings.giturl);
+    delete shareSettings.giturl;
+    return {
+      ...shareSettings,
+      ...ghSettings,
+    };
   } else {
     // github url
     const ghSettings = getGitHubSettings(url);

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -402,8 +402,11 @@ describe('Test project', () => {
     };
     const github = await getProjectFromUrl(mockTab('https://github.com/adobe/blog/tree/stage'));
     expect(github).to.eql(settings);
-    const share = await getProjectFromUrl(mockTab('https://www.aem.live/tools/sidekick/?giturl=https://github.com/adobe/blog/tree/stage'));
-    expect(share).to.eql(settings);
+    const share = await getProjectFromUrl(mockTab('https://www.aem.live/tools/sidekick/?giturl=https://github.com/adobe/blog/tree/stage&project=Blog'));
+    expect(share).to.eql({
+      project: 'Blog',
+      ...settings,
+    });
     const nomatch = await getProjectFromUrl(mockTab('https://blog.adobe.com'));
     expect(nomatch).to.eql({});
     urlCache.set(mockTab('https://blog.adobe.com'), settings);


### PR DESCRIPTION
Fix #179 