### PR TITLE
chore: handle 401 from bulk job creation

### DIFF
--- a/src/extension/app/utils/admin-client.js
+++ b/src/extension/app/utils/admin-client.js
@@ -140,6 +140,9 @@ export class AdminClient {
         // preview: unsupported file type
         message = this.appStore.i18n('error_preview_415');
       }
+    } else if (status === 401 && path === '/*') {
+      // bulk operation requires login
+      message = this.appStore.i18n(`bulk_error_${action}_login_required`);
     } else {
       // error key fallbacks
       message = this.appStore.i18n(`error_${action}_${status}`)

--- a/test/app/utils/admin-client.test.js
+++ b/test/app/utils/admin-client.test.js
@@ -519,6 +519,12 @@ describe('Test Admin Client', () => {
       expect(res).to.equal('Failed to activate configuration: something went wrong');
     });
 
+    it('should return localized error for 401 on bulk operation', () => {
+      path = '/*';
+      const res = adminClient.getLocalizedError('publish', path, 401);
+      expect(res).to.equal('You need to sign in to publish more than 100 files.');
+    });
+
     it('should return localized error fallbacks', () => {
       const res1 = adminClient.getLocalizedError('publish', path, 404);
       expect(res1).to.match(/generate preview first/);


### PR DESCRIPTION
The job API requires users to be signed in for operations on more than 100 URLs.