### PR TITLE
GH-244 - Extensible source support

### DIFF
--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -598,12 +598,14 @@ export class AppStore {
    * @returns {string} The content source label
    */
   getContentSourceLabel() {
-    const { contentSourceType } = this.siteStore;
+    const { contentSourceType, contentSourceEditLabel } = this.siteStore;
 
     if (contentSourceType === 'onedrive') {
       return 'SharePoint';
     } else if (contentSourceType === 'google') {
       return 'Google Drive';
+    } else if (contentSourceEditLabel) {
+      return contentSourceEditLabel;
     } else {
       return 'BYOM';
     }
@@ -1088,6 +1090,27 @@ export class AppStore {
     }
   }
 
+  getBYOMSourceUrl() {
+    const {
+      owner,
+      repo,
+      contentSourceUrl,
+      contentSourceEditPattern,
+    } = this.siteStore;
+    if (!contentSourceEditPattern || typeof contentSourceEditPattern !== 'string') return undefined;
+
+    let { pathname } = this.location;
+    if (pathname.endsWith('/')) pathname += 'index';
+
+    const url = contentSourceEditPattern
+      .replace('{{contentSourceUrl}}', contentSourceUrl)
+      .replace('{{org}}', owner)
+      .replace('{{site}}', repo)
+      .replace('{{pathname}}', pathname);
+
+    return url;
+  }
+
   /**
    * Switches to (or opens) a given environment.
    * @param {string} targetEnv One of the following environments:
@@ -1128,7 +1151,7 @@ export class AppStore {
 
     if (targetEnv === 'edit') {
       const updatedStatus = await this.fetchStatus(false, true);
-      envUrl = updatedStatus.edit && updatedStatus.edit.url;
+      envUrl = updatedStatus.edit?.url || this.getBYOMSourceUrl();
     }
 
     const [customView] = this.findViews(VIEWS.CUSTOM);

--- a/src/extension/app/store/site.js
+++ b/src/extension/app/store/site.js
@@ -239,6 +239,8 @@ export class SiteStore {
       lang,
       contentSourceUrl,
       contentSourceType,
+      editUrlLabel,
+      editUrlPattern,
       previewHost,
       liveHost,
       outerHost: legacyLiveHost,
@@ -273,6 +275,9 @@ export class SiteStore {
     this.giturl = giturl;
     this.contentSourceUrl = contentSourceUrl;
     this.contentSourceType = contentSourceType;
+    this.contentSourceEditLabel = editUrlLabel;
+    this.contentSourceEditPattern = editUrlPattern;
+
     this.mountpoints = contentSourceUrl ? [contentSourceUrl] : (mountpoints || []);
     [this.mountpoint] = this.mountpoints;
     this.adminVersion = adminVersion;

--- a/src/extension/types/typedefs.js
+++ b/src/extension/types/typedefs.js
@@ -44,6 +44,8 @@
  * @prop {string} [liveHost] The host name of a custom live CDN
  * @prop {string} [host] The production host name to publish content to
  * @prop {string} [devOrigin] The origin of the local development environment
+ * @prop {string} [editUrlLabel] The custom label of the edit content source
+ * @prop {string} [editUrlPattern] The pattern of the edit content source
  * @prop {string} [adminVersion] The specific version of admin service to use
  * @prop {boolean} [disabled] Is the project disabled?
  * @description Represents the sidekick configuration from the user via the options view

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -516,6 +516,20 @@ describe('Test App Store', () => {
       expect(fetchStatusSpy.calledWith(false, true)).to.be.true;
     });
 
+    it('switches from preview to BYOM editor', async () => {
+      instance.siteStore.contentSourceUrl = 'https://aemcloud.com';
+      instance.siteStore.contentSourceEditLabel = 'Universal Editor';
+      instance.siteStore.contentSourceEditPattern = '{{contentSourceUrl}}{{pathname}}?cmd=open';
+
+      const fetchStatusStub = sidekickTest.sandbox.stub(instance, 'fetchStatus');
+      fetchStatusStub.resolves({});
+
+      instance.location = new URL(mockStatus.preview.url);
+      instance.status = mockStatus;
+      await instance.switchEnv('edit');
+      expect(loadPage.calledWith('https://aemcloud.com/index?cmd=open')).to.be.true;
+    });
+
     it('switches from live to preview', async () => {
       instance.location = new URL(mockStatus.live.url);
       instance.status = mockStatus;
@@ -1531,6 +1545,12 @@ describe('Test App Store', () => {
     it('should return "Google Drive" if sourceLocation includes "gdrive:"', () => {
       instance.siteStore.contentSourceType = 'google';
       expect(instance.getContentSourceLabel()).to.equal('Google Drive');
+    });
+
+    it('should return "Document Authoring" if a label is provided', () => {
+      instance.siteStore.contentSourceType = 'markup';
+      instance.siteStore.contentSourceEditLabel = 'Document Authoring';
+      expect(instance.getContentSourceLabel()).to.equal('Document Authoring');
     });
 
     it('should return "BYOM" for everything else', () => {

--- a/test/app/store/site.test.js
+++ b/test/app/store/site.test.js
@@ -192,5 +192,18 @@ describe('Test Site Store', () => {
       expect(appStore.siteStore.owner).to.equal('adobe');
       expect(appStore.siteStore.repo).to.equal('aem-boilerplate');
     });
+
+    it('with custom sourceEditUrl', async () => {
+      /**
+       * @type {SidekickOptionsConfig | ClientConfig}
+       */
+      const config = {
+        ...defaultConfig,
+        editUrlLabel: 'Universal Editor',
+        editUrlPattern: '{{contentSourceUrl}}{{pathname}}?cmd=open',
+      };
+      await appStore.loadContext(sidekickElement, config);
+      expect(appStore.siteStore.contentSourceEditLabel).to.equal('Universal Editor');
+    });
   });
 });


### PR DESCRIPTION
## Description
* Provides ability to let project spec an `editUrlFormat` object
* Supports `{{contentSourceUrl}} {{org}} {{site}} {{pathname}}` placeholders in pattern

## API
### UE
```json
{
  "project": "XWalk Block Collection",
  "editUrlLabel": "Universal Editor",
  "editUrlPattern": "{{contentSourceUrl}}{{pathname}}?cmd=open"
}
```

### DA
```json
{
  "project": "DA Block Collection",
  "editUrlLabel": "Document Authoring",
  "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}{{pathname}}"
}
```

## Related Issue

Resolves: GH-244

## Motivation and Context

See the GH issue.

## How Has This Been Tested?

E2E for now. Once approach is agreed upon, will write tests.

## Screenshots (if appropriate):
<img width="655" alt="Screenshot 2024-09-06 at 1 43 20 PM" src="https://github.com/user-attachments/assets/eebbb775-b4fa-4613-ba6c-0361cfbe6bb0">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
