### PR TITLE
fix: don't remove nocache at start of content script

### DIFF
--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -42,9 +42,6 @@ function removeCacheParam(href = window.location.href) {
   // ensure hlx namespace
   window.hlx = window.hlx || {};
 
-  // remove cache buster from URL
-  removeCacheParam();
-
   const { getDisplay, toggleDisplay } = await import('./display.js');
   const display = await getDisplay();
 
@@ -117,8 +114,10 @@ function removeCacheParam(href = window.location.href) {
       return;
     }
 
-    const sidekick = document.querySelector('aem-sidekick');
+    // remove cache buster from URL
+    removeCacheParam();
 
+    const sidekick = document.querySelector('aem-sidekick');
     if (configMatches.length > 0) {
       if (sidekick) {
         // Toggle sidekick display


### PR DESCRIPTION
Fixes: #251 

Removing the `nocache` at the start of the content script was causing `checkTab` to be called multiple times in a row which resulted in the aem-sidekick element getting injected into the page multiple times. Multiple events were fired before the element was added to page, our check to make sure not to add it twice was then failing.

`const sidekick = document.querySelector('aem-sidekick');` is still undefined as these events are fired.