### PR TITLE
feat: Visually align Source in Editor view [env-switcher]

### DIFF
--- a/src/extension/app/components/action-bar/menu-item/menu-item.css.js
+++ b/src/extension/app/components/action-bar/menu-item/menu-item.css.js
@@ -23,6 +23,17 @@ export const style = css`
     font-weight: 700;
   }
 
+  :host(.current-env.env-edit[aria-disabled="true"]) [name="description"]::slotted(*) {
+    font-weight: 400;
+    font-size: var(--spectrum-font-size-50);
+  }
+
+  :host(.current-env.env-edit[aria-disabled="true"]) {
+    background-color: var(--spectrum-gray-200);
+    border: 1px solid var(--spectrum2-edit-border-default);
+    border-radius: var(--spectrum2-default-border-radius);
+  }
+
   :host(:hover) {
     border-radius: var(--spectrum2-default-border-radius);
   }
@@ -77,7 +88,9 @@ export const style = css`
 
   :host(.env-edit) {
     display: flex;
-    height: 40px;
+    height: 50px;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   ::slotted([slot=icon]) {

--- a/src/extension/app/components/action-bar/menu-item/menu-item.css.js
+++ b/src/extension/app/components/action-bar/menu-item/menu-item.css.js
@@ -15,10 +15,6 @@
 import { css } from 'lit';
 
 export const style = css`
-  :host(.current-env) {
-    margin-bottom: 7px;
-  }
-
   :host(.current-env) #label {
     font-weight: 700;
   }

--- a/src/extension/app/components/action-bar/menu-item/menu-item.css.js
+++ b/src/extension/app/components/action-bar/menu-item/menu-item.css.js
@@ -97,7 +97,8 @@ export const style = css`
   :host(.env-edit) ::slotted([slot=icon]) {
     position: absolute;
     right: 7px;
-    top: 11px;
+    top: 50%;
+    transform: translateY(-50%);
     color: var(--spectrum-menu-item-label-icon-color-default);
   }
 

--- a/src/extension/app/components/action-bar/menu-item/menu-item.css.js
+++ b/src/extension/app/components/action-bar/menu-item/menu-item.css.js
@@ -82,7 +82,7 @@ export const style = css`
   :host(.current-env.env-live[aria-disabled="true"]) [name="description"]::slotted(*),
   :host(.current-env.env-prod[aria-disabled="true"]) [name="description"]::slotted(*),
   :host(.current-env.env-live[disabled]) [name="description"]::slotted(*),
-    :host(.current-env.env-prod[disabled]) [name="description"]::slotted(*) {
+  :host(.current-env.env-prod[disabled]) [name="description"]::slotted(*) {
     color: var(--spectrum2-live-content-default);
   }
 
@@ -102,6 +102,7 @@ export const style = css`
     position: absolute;
     right: 7px;
     top: 11px;
+    color: var(--spectrum-menu-item-label-icon-color-default);
   }
 
   sp-status-light {

--- a/src/extension/app/components/plugin/env-switcher/env-switcher.js
+++ b/src/extension/app/components/plugin/env-switcher/env-switcher.js
@@ -114,7 +114,7 @@ export class EnvironmentSwitcher extends ConnectedElement {
    * @returns {string} - The last modified label
    */
   getLastModifiedLabel(id, lastModified) {
-    const envId = (id === 'dev') ? 'preview' : id;
+    const envId = id === 'dev' ? 'preview' : id;
     return lastModified
       ? this.appStore.i18n(`${envId}_last_updated`).replace('$1', getTimeAgo(this.appStore.languageDict, lastModified))
       : this.appStore.i18n(`${envId}_never_updated`);

--- a/src/extension/app/components/plugin/env-switcher/env-switcher.js
+++ b/src/extension/app/components/plugin/env-switcher/env-switcher.js
@@ -114,7 +114,14 @@ export class EnvironmentSwitcher extends ConnectedElement {
    * @returns {string} - The last modified label
    */
   getLastModifiedLabel(id, lastModified) {
-    const envId = id === 'dev' ? 'preview' : id;
+    let envId;
+    if (id === 'dev') {
+      envId = 'preview';
+    } else if (id === 'edit') {
+      envId = 'edit';
+    } else {
+      envId = id;
+    }
     return lastModified
       ? this.appStore.i18n(`${envId}_last_updated`).replace('$1', getTimeAgo(this.appStore.languageDict, lastModified))
       : this.appStore.i18n(`${envId}_never_updated`);
@@ -140,7 +147,7 @@ export class EnvironmentSwitcher extends ConnectedElement {
       });
     }
 
-    const label = id === 'edit' ? this.appStore.i18n('open_in').replace('$1', contentSourceLabel) : this.envNames[id];
+    const label = id === 'edit' ? this.envNames.edit : this.envNames[id];
     const menuItem = createTag({
       tag: 'sk-menu-item',
       text: label,
@@ -173,6 +180,21 @@ export class EnvironmentSwitcher extends ConnectedElement {
           slot: 'icon',
         },
       });
+
+      const currentEnvironment = this.currentEnv;
+      const descriptionText = currentEnvironment === 'edit'
+        ? this.getLastModifiedLabel(id, lastModified)
+        : this.appStore.i18n('open_in').replace('$1', contentSourceLabel);
+
+      const description = createTag({
+        tag: 'span',
+        text: descriptionText,
+        attrs: {
+          slot: 'description',
+        },
+      });
+
+      menuItem.appendChild(description);
 
       const { status } = this.appStore;
 
@@ -217,12 +239,13 @@ export class EnvironmentSwitcher extends ConnectedElement {
     picker.innerHTML = '';
 
     // Pull mod dates from status
+    const editLastMod = status.edit?.lastModified;
     const previewLastMod = status.preview?.lastModified;
     const liveLastMod = status.live?.lastModified;
 
     const environmentsHeader = this.createHeader('environments');
     const devMenuItem = this.createMenuItem('dev', {}, previewLastMod);
-    const editMenuItem = this.createMenuItem('edit', {});
+    const editMenuItem = this.createMenuItem('edit', {}, editLastMod);
     const previewMenuItem = this.createMenuItem('preview', {}, previewLastMod);
     const liveMenuItem = this.createMenuItem('live', {}, liveLastMod);
     const prodMenuItem = this.createMenuItem('prod', {}, liveLastMod);
@@ -250,6 +273,7 @@ export class EnvironmentSwitcher extends ConnectedElement {
         editMenuItem.classList.add('current-env');
         picker.append(
           environmentsHeader,
+          editMenuItem,
           previewMenuItem,
           liveMenuItem,
         );

--- a/src/extension/app/components/plugin/env-switcher/env-switcher.js
+++ b/src/extension/app/components/plugin/env-switcher/env-switcher.js
@@ -174,8 +174,7 @@ export class EnvironmentSwitcher extends ConnectedElement {
         },
       });
 
-      const currentEnvironment = this.currentEnv;
-      const descriptionText = currentEnvironment === 'edit'
+      const descriptionText = this.currentEnv === 'edit'
         ? this.getLastModifiedLabel(id, lastModified)
         : this.appStore.i18n('open_in').replace('$1', contentSourceLabel);
 

--- a/src/extension/app/components/plugin/env-switcher/env-switcher.js
+++ b/src/extension/app/components/plugin/env-switcher/env-switcher.js
@@ -114,14 +114,7 @@ export class EnvironmentSwitcher extends ConnectedElement {
    * @returns {string} - The last modified label
    */
   getLastModifiedLabel(id, lastModified) {
-    let envId;
-    if (id === 'dev') {
-      envId = 'preview';
-    } else if (id === 'edit') {
-      envId = 'edit';
-    } else {
-      envId = id;
-    }
+    const envId = (id === 'dev') ? 'preview' : id;
     return lastModified
       ? this.appStore.i18n(`${envId}_last_updated`).replace('$1', getTimeAgo(this.appStore.languageDict, lastModified))
       : this.appStore.i18n(`${envId}_never_updated`);
@@ -147,7 +140,7 @@ export class EnvironmentSwitcher extends ConnectedElement {
       });
     }
 
-    const label = id === 'edit' ? this.envNames.edit : this.envNames[id];
+    const label = this.envNames[id];
     const menuItem = createTag({
       tag: 'sk-menu-item',
       text: label,

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_title__",
-  "version": "1.32.1",
+  "version": "2.0.0",
   "author": "Adobe",
   "homepage_url": "https://www.hlx.live/tools/sidekick/",
   "default_locale": "en",

--- a/test/app/components/plugin/plugin-action-bar.test.js
+++ b/test/app/components/plugin/plugin-action-bar.test.js
@@ -148,7 +148,7 @@ describe('Plugin action bar', () => {
         'tools',
       ]);
 
-      expectEnvPlugin(['preview', 'prod']);
+      expectEnvPlugin(['edit', 'preview', 'prod']);
 
       // Should fallback to id for label if title not provided
       const assetLibraryPlugin = recursiveQuery(sidekick, '.assets');
@@ -237,7 +237,7 @@ describe('Plugin action bar', () => {
         'edit-preview',
       ]);
 
-      expectEnvPlugin(['preview', 'live']);
+      expectEnvPlugin(['edit', 'preview', 'live']);
     });
 
     it('isEditor - custom config with prod host', async () => {
@@ -254,7 +254,7 @@ describe('Plugin action bar', () => {
         'edit-preview',
       ]);
 
-      expectEnvPlugin(['preview', 'prod']);
+      expectEnvPlugin(['edit', 'preview', 'prod']);
     });
 
     it('isPreview - custom config with prod host', async () => {

--- a/test/app/components/plugin/plugin-action-bar.test.js
+++ b/test/app/components/plugin/plugin-action-bar.test.js
@@ -247,8 +247,6 @@ describe('Plugin action bar', () => {
         .mockEditorAdminEnvironment(EditorMockEnvironments.EDITOR)
         .createSidekick();
 
-      await sidekickTest.awaitStatusFetched();
-
       await sidekickTest.awaitEnvSwitcher();
 
       const envPlugin = recursiveQuery(sidekickTest.sidekick, 'env-switcher');

--- a/test/app/components/plugin/plugin-action-bar.test.js
+++ b/test/app/components/plugin/plugin-action-bar.test.js
@@ -242,18 +242,17 @@ describe('Plugin action bar', () => {
 
     it('Editor - should display "last edited" description for Source', async () => {
       sidekickTest
-        .mockFetchEditorStatusSuccess(HelixMockContentSources.GDRIVE, HelixMockContentType.DOC)
+        .mockFetchEditorStatusSuccess(HelixMockContentSources.SHAREPOINT, HelixMockContentType.DOC)
         .mockFetchSidekickConfigSuccess(false, false)
         .mockEditorAdminEnvironment(EditorMockEnvironments.EDITOR)
         .createSidekick();
 
+      await sidekickTest.awaitStatusFetched();
+
       await sidekickTest.awaitEnvSwitcher();
 
-      const actionBar = recursiveQuery(sidekick, 'action-bar');
-      const envPlugin = recursiveQuery(actionBar, 'env-switcher');
+      const envPlugin = recursiveQuery(sidekickTest.sidekick, 'env-switcher');
       const menuItem = recursiveQuery(envPlugin, 'sk-menu-item.env-edit');
-
-      const lastModifiedLabel = 'Last edited Dec 19, 2023, 9:12 PM';
 
       await waitUntil(() => {
         const descriptionElement = menuItem.querySelector('[slot="description"]');
@@ -261,7 +260,9 @@ describe('Plugin action bar', () => {
       }, 'Description element not found', { timeout: 5000 });
 
       const description = menuItem.querySelector('[slot="description"]');
-      expect(description.textContent).to.equal(lastModifiedLabel);
+      const localeDateString = description.textContent.substring(11);
+      expect(localeDateString.length).to.be.greaterThan(0);
+      expect(new Date(localeDateString).toUTCString()).to.equal('Fri, 21 Jul 2023 19:58:00 GMT');
     });
 
     it('Preview - should display "open in" description for Source', async () => {

--- a/test/app/components/plugin/plugin-action-bar.test.js
+++ b/test/app/components/plugin/plugin-action-bar.test.js
@@ -240,6 +240,48 @@ describe('Plugin action bar', () => {
       expectEnvPlugin(['edit', 'preview', 'live']);
     });
 
+    it('Editor - should display "last edited" description for Source', async () => {
+      sidekickTest
+        .mockFetchEditorStatusSuccess(HelixMockContentSources.GDRIVE, HelixMockContentType.DOC)
+        .mockFetchSidekickConfigSuccess(false, false)
+        .mockEditorAdminEnvironment(EditorMockEnvironments.EDITOR)
+        .createSidekick();
+
+      await sidekickTest.awaitEnvSwitcher();
+
+      const actionBar = recursiveQuery(sidekick, 'action-bar');
+      const envPlugin = recursiveQuery(actionBar, 'env-switcher');
+      const menuItem = recursiveQuery(envPlugin, 'sk-menu-item.env-edit');
+
+      const lastModifiedLabel = 'Last edited Dec 19, 2023, 9:12 PM';
+
+      await waitUntil(() => {
+        const descriptionElement = menuItem.querySelector('[slot="description"]');
+        return descriptionElement;
+      }, 'Description element not found', { timeout: 5000 });
+
+      const description = menuItem.querySelector('[slot="description"]');
+      expect(description.textContent).to.equal(lastModifiedLabel);
+    });
+
+    it('Preview - should display "open in" description for Source', async () => {
+      sidekickTest
+        .mockFetchStatusSuccess()
+        .mockFetchSidekickConfigSuccess(false)
+        .mockHelixEnvironment(HelixMockEnvironments.PREVIEW);
+
+      sidekick = sidekickTest.createSidekick();
+
+      await sidekickTest.awaitEnvSwitcher();
+
+      const actionBar = recursiveQuery(sidekick, 'action-bar');
+      const envPlugin = recursiveQuery(actionBar, 'env-switcher');
+      const menuItem = recursiveQuery(envPlugin, 'sk-menu-item.env-edit');
+
+      const description = menuItem.querySelector('[slot="description"]');
+      expect(description.textContent).to.equal('Open in Google Drive');
+    });
+
     it('isEditor - custom config with prod host', async () => {
       sidekickTest
         .mockFetchEditorStatusSuccess(HelixMockContentSources.SHAREPOINT, HelixMockContentType.DOC)

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -86,7 +86,7 @@ describe('Test App Store', () => {
 
     await waitUntil(() => appStore.status.webPath, 'Status never loaded');
     expect(appStore.status.webPath).to.equal('/');
-    expect(appStore.status.edit.status).to.equal(undefined);
+    expect(appStore.status.edit.status).to.equal(200);
     expect(appStore.status.live.status).to.equal(200);
   }
 

--- a/test/fixtures/helix-admin.js
+++ b/test/fixtures/helix-admin.js
@@ -156,6 +156,27 @@ export const defaultEnvJSON = {
   contentSourceType: 'onedrive',
 };
 
+export const defaultSharepointEditInfo = {
+  status: 200,
+  url: 'https://adobe.sharepoint.com/sites/foo/_layouts/15/Doc.aspx?sourcedoc=%7B207F9725-D73A-4C98-A87D-DC6AD4360373%7D&file=bar.docx&action=default&mobileredirect=true',
+  name: 'bar.docx',
+  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  folders: [
+    {
+      name: 'foo',
+      url: 'https://adobe.sharepoint.com/sites/foo/Shared%20Documents/site/foo',
+      path: '/foo',
+    },
+    {
+      name: 'site',
+      url: 'https://adobe.sharepoint.com/sites/foo/Shared%20Documents/site',
+      path: '/',
+    },
+  ],
+  lastModified: 'Fri, 21 Jul 2023 19:58:27 GMT',
+  sourceLocation: 'onedrive:/drives/b!SRYzYQL770qsQPbhXU8sWMnBDDbKRg1Npp5iKHaWz7cyd_ev_i2JTI5LB0GcN0hc/items/01HFRI53JFS57SAOWXTBGKQ7O4NLKDMA3T',
+};
+
 /**
  * status request stubs
  */
@@ -188,7 +209,7 @@ export const defaultSharepointStatusResponse = {
       'write',
     ],
   },
-  edit: {},
+  edit: defaultSharepointEditInfo,
   code: {
     status: 400,
     permissions: [
@@ -266,27 +287,6 @@ export const defaultCodeStatusResponse = {
     sourceLastModified: 'Thu, 06 Jun 2024 19:54:13 GMT',
     sourceLocation: 'https://raw.githubusercontent.com/adobecom/blog/main/scripts/scripts.js',
   },
-};
-
-export const defaultSharepointEditInfo = {
-  status: 200,
-  url: 'https://adobe.sharepoint.com/sites/foo/_layouts/15/Doc.aspx?sourcedoc=%7B207F9725-D73A-4C98-A87D-DC6AD4360373%7D&file=bar.docx&action=default&mobileredirect=true',
-  name: 'bar.docx',
-  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  folders: [
-    {
-      name: 'foo',
-      url: 'https://adobe.sharepoint.com/sites/foo/Shared%20Documents/site/foo',
-      path: '/foo',
-    },
-    {
-      name: 'site',
-      url: 'https://adobe.sharepoint.com/sites/foo/Shared%20Documents/site',
-      path: '/',
-    },
-  ],
-  lastModified: 'Fri, 21 Jul 2023 19:58:27 GMT',
-  sourceLocation: 'onedrive:/drives/b!SRYzYQL770qsQPbhXU8sWMnBDDbKRg1Npp5iKHaWz7cyd_ev_i2JTI5LB0GcN0hc/items/01HFRI53JFS57SAOWXTBGKQ7O4NLKDMA3T',
 };
 
 export const defaultGdriveStatusResponse = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[env-switcher] visually align "source" item with the others in the popover (along with last modified/edited timestamp)

## Related Issue

Fix #283 

## Screenshots (if appropriate):
**Preview:**
<img width="675" alt="image" src="https://github.com/user-attachments/assets/7ac72e7a-15ca-4792-bff0-879b60047f00">

**Editor:**
<img width="614" alt="image" src="https://github.com/user-attachments/assets/f6c7aa74-e534-4b24-9f27-60b0c152e117">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
