### PR TITLE
Rework notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/aem-sidekick",
-  "version": "1.32.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/aem-sidekick",
-      "version": "1.32.1",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit/context": "1.1.2",

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -133,12 +133,21 @@
     "config_project_add": {
       "message": "Add this project"
     },
+    "config_add_project_headline": {
+      "message": "Add project"
+    },
+    "config_remove_project_headline": {
+      "message": "Remove project"
+    },
     "config_project_added": {
       "message": "$1 successfully added",
       "description": "Project added"
     },
     "config_project_disable": {
       "message": "Disable this project"
+    },
+    "config_project_headline": {
+      "message": "Project"
     },
     "config_project_disabled": {
       "message": "$1 disabled",

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -146,8 +146,11 @@
     "config_project_disable": {
       "message": "Disable this project"
     },
-    "config_project_headline": {
-      "message": "Project"
+    "config_project_enabled_headline": {
+      "message": "Project enabled"
+    },
+    "config_project_disabled_headline": {
+      "message": "Project disabled"
     },
     "config_project_disabled": {
       "message": "$1 disabled",

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -166,6 +166,12 @@
     "config_project_imported_multiple": {
       "message": "Successfully imported $1 projects from AEM Sidekick v6."
     },
+    "config_project_import_headline": {
+      "message": "Import projects"
+    },
+    "config_project_import_sidekick_not_found": {
+      "message": "Legacy sidekick not found. If the extension is installed but currently disabled, please enable it and try again."
+    },
     "config_project_pick": {
       "message": "Pick a project"
     },
@@ -354,26 +360,8 @@
     "extensions": {
       "message": "Extensions"
     },
-    "help": {
-      "message": "Help"
-    },
-    "help_acknowledge": {
-      "message": "Got it!"
-    },
-    "help_close_acknowledge": {
-      "message": "Don't show help topic again"
-    },
-    "help_close_dismiss": {
-      "message": "Show help topic again later"
-    },
-    "help_close_opt_out": {
-      "message": "Never show any help topics"
-    },
-    "help_current": {
-      "message": "This tip"
-    },
-    "help_next": {
-      "message": "Next tip"
+    "next": {
+      "message": "Next"
     },
     "help_opt_out": {
       "message": "Don't show any help"

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -134,10 +134,10 @@
       "message": "Add this project"
     },
     "config_add_project_headline": {
-      "message": "Add project"
+      "message": "Added project"
     },
     "config_remove_project_headline": {
-      "message": "Remove project"
+      "message": "Removed project"
     },
     "config_project_added": {
       "message": "$1 successfully added",

--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -64,6 +64,7 @@ async function updateAuthToken({
 
 function notificationConfirmCallback(tabId) {
   return async () => {
+    /* istanbul ignore next */
     await chrome.tabs.reload(tabId, { bypassCache: true });
   };
 }

--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -103,11 +103,21 @@ async function addRemoveProject(tab) {
       await addProject(config);
       project = await getProject(config);
       const i18nKey = 'config_project_added';
-      await showSidekickNotification(tab.id, { message: chrome.i18n.getMessage(i18nKey, project.project || project.id), headline: 'Add project' }, notificationConfirmCallback(tab.id));
+      await showSidekickNotification(tab.id,
+        {
+          message: chrome.i18n.getMessage(i18nKey, project.project || project.id),
+          headline: chrome.i18n.getMessage('config_add_project_headline'),
+        },
+        notificationConfirmCallback(tab.id));
     } else {
       await deleteProject(`${owner}/${repo}`);
       const i18nKey = 'config_project_removed';
-      await showSidekickNotification(tab.id, { message: chrome.i18n.getMessage(i18nKey, project.project || project.id), headline: 'Remove project' }, notificationConfirmCallback(tab.id));
+      await showSidekickNotification(tab.id,
+        {
+          message: chrome.i18n.getMessage(i18nKey, project.project || project.id),
+          headline: chrome.i18n.getMessage('config_remove_project_headline'),
+        },
+        notificationConfirmCallback(tab.id));
     }
   }
 }
@@ -125,7 +135,12 @@ async function enableDisableProject(tab) {
       ? 'config_project_enabled'
       : 'config_project_disabled';
 
-    await showSidekickNotification({ message: chrome.i18n.getMessage(i18nKey, project.project || project.id), headline: 'Project' }, notificationConfirmCallback(id));
+    await showSidekickNotification(tab.id,
+      {
+        message: chrome.i18n.getMessage(i18nKey, project.project || project.id),
+        headline: chrome.i18n.getMessage('config_project_headline'),
+      },
+      notificationConfirmCallback(id));
   }
 }
 
@@ -135,14 +150,22 @@ async function enableDisableProject(tab) {
 async function importProjects(tab) {
   const sidekickId = await detectLegacySidekick();
   if (!sidekickId) {
-    await showSidekickNotification(tab.id, { message: chrome.i18n.getMessage('config_project_import_sidekick_not_found'), headline: chrome.i18n.getMessage('config_project_import_headline') });
+    await showSidekickNotification(tab.id,
+      {
+        message: chrome.i18n.getMessage('config_project_import_sidekick_not_found'),
+        headline: chrome.i18n.getMessage('config_project_import_headline'),
+      });
     return;
   }
   const imported = await importLegacyProjects(sidekickId);
   const i18nKey = imported > 0
     ? `config_project_imported_${imported === 1 ? 'single' : 'multiple'}`
     : 'config_project_imported_none';
-  await showSidekickNotification(tab.id, { message: chrome.i18n.getMessage(i18nKey, `${imported}`), headline: chrome.i18n.getMessage('config_project_import_headline') });
+  await showSidekickNotification(tab.id,
+    {
+      message: chrome.i18n.getMessage(i18nKey, `${imported}`),
+      headline: chrome.i18n.getMessage('config_project_import_headline'),
+    });
 }
 
 /**

--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -156,11 +156,14 @@ async function enableDisableProject(tab) {
     const i18nKey = project.disabled
       ? 'config_project_enabled'
       : 'config_project_disabled';
+    const i18nHeadlineKey = project.disabled
+      ? 'config_project_enabled_headline'
+      : 'config_project_disabled_headline';
 
     await showSidekickNotification(tab.id,
       {
         message: chrome.i18n.getMessage(i18nKey, project.project || project.id),
-        headline: chrome.i18n.getMessage('config_project_headline'),
+        headline: chrome.i18n.getMessage(i18nHeadlineKey),
       },
       notificationConfirmCallback(id));
   }

--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -80,9 +80,8 @@ export async function showSidekickIfHidden() {
  * Notification confirmation callback
  * @param {number} tabId The tab ID
  */
-function notificationConfirmCallback(tabId) {
+export function notificationConfirmCallback(tabId) {
   return async () => {
-    /* istanbul ignore next */
     await chrome.tabs.reload(tabId, { bypassCache: true });
   };
 }

--- a/src/extension/app/aem-sidekick.js
+++ b/src/extension/app/aem-sidekick.js
@@ -18,7 +18,7 @@ import { customElement } from 'lit/decorators.js';
 import { style } from './aem-sidekick.css.js';
 import { spectrum2 } from './spectrum-2.css.js';
 import { AppStore, appStoreContext } from './store/app.js';
-import { EXTERNAL_EVENTS } from './constants.js';
+import { ALLOWED_EXTENSION_IDS, EXTERNAL_EVENTS, MODALS } from './constants.js';
 import { detectBrowser } from './utils/browser.js';
 
 @customElement('aem-sidekick')
@@ -50,6 +50,21 @@ export class AEMSidekick extends LitElement {
     });
 
     document.dispatchEvent(new CustomEvent(EXTERNAL_EVENTS.SIDEKICK_READY));
+
+    chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+      if (msg.action === 'show_notification' && ALLOWED_EXTENSION_IDS.includes(sender.id)) {
+        const { message, headline } = msg;
+        this.appStore.showModal({
+          type: MODALS.INFO,
+          data: {
+            headline,
+            message,
+            confirmCallback: (response) => { sendResponse(response); },
+          },
+        });
+      }
+      return true;
+    });
   }
 
   /**

--- a/src/extension/app/components/dialog-wrapper/dialog-wrapper.css.js
+++ b/src/extension/app/components/dialog-wrapper/dialog-wrapper.css.js
@@ -23,4 +23,8 @@ export const style = css`
       backdrop-filter: var(--sidekick-backdrop-filter);
       -webkit-backdrop-filter: var(--sidekick-backdrop-filter);
     }
+
+    sp-dialog {
+      max-width: 450px;
+    }
  `;

--- a/src/extension/app/components/modal/modal-container.js
+++ b/src/extension/app/components/modal/modal-container.js
@@ -228,6 +228,17 @@ export class ModalContainer extends LitElement {
     const { type, data } = modal;
     const options = {};
     switch (type) {
+      case MODALS.INFO:
+        options.underlay = true;
+        options.headline = data?.headline ?? '';
+        options.confirmLabel = data?.confirmLabel ?? this.appStore.i18n('ok');
+        options.confirmCallback = data?.confirmCallback;
+        options.secondaryLabel = data?.secondaryLabel;
+        options.secondaryCallback = data?.secondaryCallback;
+        options.content = html`
+          ${data.message}
+        `;
+        break;
       case MODALS.ERROR:
         options.dismissable = false;
         options.headline = data?.headline ?? this.appStore.i18n('error');

--- a/src/extension/app/constants.js
+++ b/src/extension/app/constants.js
@@ -58,6 +58,7 @@ export const EXTERNAL_EVENTS = {
  * @enum {string}
  */
 export const MODALS = {
+  INFO: 'info',
   ERROR: 'error',
   CONFIRM: 'confirm',
   DELETE: 'delete',
@@ -114,6 +115,15 @@ export const STATE = {
   MEDIA: 'media_state',
   READY: 'ready_state',
 };
+
+/**
+ * The chrome extension IDs that are allowed to send messages to the extension.
+ * @type {string[]}
+ */
+export const ALLOWED_EXTENSION_IDS = [
+  'igkmdomcgoebiipaifhmpfjhbjccggml',
+  'iijidanmjddcjacejcjofhcjmgkkiijo',
+];
 
 /**
  * The SVG icons.

--- a/src/extension/app/constants.js
+++ b/src/extension/app/constants.js
@@ -122,6 +122,7 @@ export const STATE = {
  */
 export const ALLOWED_EXTENSION_IDS = [
   'igkmdomcgoebiipaifhmpfjhbjccggml',
+  'dfeojcdljkdfebmdcmilekahpcjkafdp',
   'iijidanmjddcjacejcjofhcjmgkkiijo',
 ];
 

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -21,8 +21,6 @@ import {
   checkViewDocSource,
 } from './actions.js';
 import { configureAuthAndCorsHeaders } from './auth.js';
-import { getProjectMatches, getProjects } from './project.js';
-import { updateIcon } from './ui.js';
 
 chrome.action.onClicked.addListener(async ({ id }) => {
   // toggle the sidekick when the action is clicked
@@ -57,9 +55,7 @@ chrome.runtime.onMessageExternal.addListener(async (message, sender, sendRespons
 chrome.storage.onChanged.addListener(async (changes, storageArea) => {
   if (storageArea === 'local' && changes.display) {
     const tab = await getCurrentTab();
-    const projects = await getProjects();
-    const matches = await getProjectMatches(projects, tab);
-    await updateIcon({ matches });
+    await checkTab(tab.id);
   }
 });
 

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -10,7 +10,6 @@
     "activeTab",
     "contextMenus",
     "declarativeNetRequest",
-    "notifications",
     "scripting",
     "storage"
   ],

--- a/src/extension/project.js
+++ b/src/extension/project.js
@@ -550,12 +550,7 @@ export async function detectLegacySidekick() {
  * Imports projects from legacy sidekick.
  * @returns {Promise<number>} The number of imported projects
  */
-export async function importLegacyProjects() {
-  // look for legacy sidekick id
-  const sidekickId = await detectLegacySidekick();
-  if (!sidekickId) {
-    return 0;
-  }
+export async function importLegacyProjects(sidekickId) {
   return new Promise((resolve) => {
     let importedProjects = 0;
     try {

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -19,6 +19,7 @@ import {
   checkViewDocSource,
   externalActions,
   internalActions,
+  notificationConfirmCallback,
 } from '../src/extension/actions.js';
 import chromeMock from './mocks/chrome.js';
 import { error, mockTab } from './test-utils.js';
@@ -369,5 +370,12 @@ describe('Test actions', () => {
     // tab with vds=true
     await checkViewDocSource(1);
     expect(createSpy.callCount).to.equal(1);
+  });
+
+  it('notificationConfirmCallback', async () => {
+    const reloadStub = sandbox.stub(chrome.tabs, 'reload');
+    const callback = notificationConfirmCallback(1);
+    await callback();
+    expect(reloadStub.calledOnce).to.be.true;
   });
 });

--- a/test/app/components/modal/modal.test.js
+++ b/test/app/components/modal/modal.test.js
@@ -346,6 +346,7 @@ describe('Modals', () => {
 
       const confirmButton = recursiveQuery(dialogWrapper, 'sp-button[variant="accent"]');
       expect(confirmButton.textContent.trim()).to.eq('Yes');
+      await waitUntil(() => confirmCallback.notCalled);
       confirmButton.click();
       await waitUntil(() => confirmCallback.calledOnce);
     });

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -593,7 +593,7 @@ describe('Test project', () => {
 
       it('legacy sidekick responds with new projects', async () => {
         mockLegacySidekickResponse(legacySidekickId, null, CONFIGS);
-        const imported = await importLegacyProjects();
+        const imported = await importLegacyProjects(legacySidekickId);
         expect(imported).to.equal(6);
       });
 

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -581,13 +581,13 @@ describe('Test project', () => {
 
       it('legacy sidekick responds with null', async () => {
         mockLegacySidekickResponse(legacySidekickId, null, null);
-        const imported = await importLegacyProjects();
+        const imported = await importLegacyProjects(legacySidekickId);
         expect(imported).to.equal(0);
       });
 
       it('legacy sidekick responds with empty array', async () => {
         mockLegacySidekickResponse(legacySidekickId, null, []);
-        const imported = await importLegacyProjects();
+        const imported = await importLegacyProjects(legacySidekickId);
         expect(imported).to.equal(0);
       });
 
@@ -606,16 +606,16 @@ describe('Test project', () => {
               : CONFIGS.slice(0, 1).map(({ owner, repo }) => `${owner}/${repo}`); // projects
             return { [prop]: value };
           });
-        const imported = await importLegacyProjects();
+        const imported = await importLegacyProjects(legacySidekickId);
         expect(imported).to.equal(0);
       });
 
       it('chrome.runtime.sendMessage throws', async () => {
         mockLegacySidekickResponse(legacySidekickId, null, CONFIGS)
           .withArgs(legacySidekickId)
-          .onSecondCall()
+          .onFirstCall()
           .throws(error);
-        const imported = await importLegacyProjects();
+        const imported = await importLegacyProjects(legacySidekickId);
         expect(imported).to.equal(0);
       });
     });


### PR DESCRIPTION
Move away from using native chrome notifications to in page notifications served by the sidekick. We have seen that there are many factors that could cause chrome notifications to not be displayed, by moving to in page notifications we can
guarantee that our notification is seen.

![Screenshot 2024-10-02 at 10 33 59 AM](https://github.com/user-attachments/assets/1c7ae495-df0c-4af1-8cc7-16bd8e578fda)

![Screenshot 2024-10-02 at 10 35 29 AM](https://github.com/user-attachments/assets/67372ca6-864c-45d7-ad7d-9d8f3dcb9c83)

![Screenshot 2024-10-02 at 10 35 13 AM](https://github.com/user-attachments/assets/b488700e-4b85-4011-a6a8-20c3837c90d1)

![Screenshot 2024-10-02 at 10 35 01 AM](https://github.com/user-attachments/assets/dd5e7ea1-c51b-4633-a1be-d350606b9364)

![Screenshot 2024-10-02 at 10 37 13 AM](https://github.com/user-attachments/assets/5a1d4f7a-1426-4e1e-b5d1-838c7dce7d9b)