### PR TITLE
fix: don't call checkTab when context menu clicked

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -22,11 +22,10 @@ import {
 } from './actions.js';
 import { configureAuthAndCorsHeaders } from './auth.js';
 
-chrome.action.onClicked.addListener(async ({ id }) => {
+chrome.action.onClicked.addListener(async () => {
   // toggle the sidekick when the action is clicked
   const display = await toggleDisplay();
   log.info(`sidekick is now ${display ? 'shown' : 'hidden'}`);
-  checkTab(id);
 });
 
 chrome.tabs.onUpdated.addListener(async (id, info, tab) => {


### PR DESCRIPTION
When the notification logic was changed we started calling `checkTab` when the display state was changed in local storage. I never remove the call to `checkTab` when the content menu was clicked. So it was being called twice, once when the content menu icon was clicked, and once when the display state changed.