### PR TITLE
fix: cookie-less auth cleanup. remove credentials: include

### DIFF
--- a/src/extension/utils/admin.js
+++ b/src/extension/utils/admin.js
@@ -80,6 +80,7 @@ export async function callAdmin(
   return fetch(url, {
     method,
     cache: 'no-store',
+    credentials: 'omit',
     headers: body ? { 'Content-Type': 'application/json' } : undefined,
     body: body ? JSON.stringify(body) : undefined,
   });

--- a/src/extension/utils/admin.js
+++ b/src/extension/utils/admin.js
@@ -64,7 +64,6 @@ export function createAdminUrl(
  * @param {string} [opts.method] The method to use
  * @param {Object} [opts.body] The body to send
  * @param {URLSearchParams} [opts.searchParams] The search parameters
- * @param {boolean} [opts.omitCredentials] Should we omit the credentials
  * @returns {Promise<Response>} The admin response
  */
 export async function callAdmin(

--- a/src/extension/utils/admin.js
+++ b/src/extension/utils/admin.js
@@ -75,14 +75,12 @@ export async function callAdmin(
     method = 'get',
     body = undefined,
     searchParams = new URLSearchParams(),
-    omitCredentials = false,
   } = {},
 ) {
   const url = createAdminUrl(config, api, path, searchParams);
   return fetch(url, {
     method,
     cache: 'no-store',
-    credentials: omitCredentials ? 'omit' : 'include',
     headers: body ? { 'Content-Type': 'application/json' } : undefined,
     body: body ? JSON.stringify(body) : undefined,
   });

--- a/test/utils/admin.test.js
+++ b/test/utils/admin.test.js
@@ -87,12 +87,6 @@ describe('helix-admin', () => {
       expect(options.body).to.equal('"{}"');
     });
 
-    it('calls admin api with omitCredentials', async () => {
-      await callAdmin(siteStore, 'preview', '/path/to/resource', { omitCredentials: true });
-      const options = fetchStub.getCall(0).args[1];
-      expect(options.credentials).to.equal('omit');
-    });
-
     it('calls admin api with default method', async () => {
       await callAdmin(siteStore, 'preview', '/path/to/resource');
       const options = fetchStub.getCall(0).args[1];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since the AEM Sidekick no longer uses cookies for authentication to Admin, we can remove the `credentials: 'include'` option from fetch requests to Admin.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The sidekick no longer uses cookie based authentication, so `credentials: 'include'`  should be dropped.

## How Has This Been Tested?

Manually the following flows in the browser:

Site with Admin Without login (Sharepoint)
 * Preview
 * Publish
 * Login
 * Status
 * Profile
 * Logout
 * Unpublish
 * Delete

Site with Admin With login (Sharepoint)
 * Login
 * Logout
 * Preview
 * Publish
 * Status
 * Profile
 * Unpublish
 * Delete
 * Extensions loaded

Site with Admin with login (Google Drive)
 * Login
 * Logout
 * Preview
 * Publish
 * Status
 * Profile
 * Unpublish
 * Delete

Unit tests currently not working locally, but passing in the CI.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
