### PR TITLE
fix: Restrict getAuthInfo Action to trusted Adobe Origins

### DIFF
--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -108,7 +108,7 @@ describe('Test actions', () => {
 
     // without auth info
     getStub.resolves({});
-    resp = await externalActions.getAuthInfo();
+    resp = await externalActions.getAuthInfo({}, mockTab('https://tools.aem.live'));
     expect(resp).to.deep.equal([]);
 
     // with auth info
@@ -131,8 +131,29 @@ describe('Test actions', () => {
         repo: 'baz',
       }],
     });
-    resp = await externalActions.getAuthInfo();
+
+    // trusted actors
+    resp = await externalActions.getAuthInfo({}, mockTab('https://tools.aem.live/'));
     expect(resp).to.deep.equal(['foo']);
+
+    resp = await externalActions.getAuthInfo({}, mockTab('https://tools.aem.live/test'));
+    expect(resp).to.deep.equal(['foo']);
+
+    resp = await externalActions.getAuthInfo({}, mockTab('https://feature--helix-labs-website--adobe.aem.page/feature'));
+    expect(resp).to.deep.equal(['foo']);
+
+    // untrusted actors
+    resp = await externalActions.getAuthInfo({}, mockTab('https://evil.live'));
+    expect(resp).to.deep.equal([]);
+
+    resp = await externalActions.getAuthInfo({}, mockTab('https://main--site--owner.aem.live'));
+    expect(resp).to.deep.equal([]);
+
+    resp = await externalActions.getAuthInfo({}, mockTab('https://tools.aem.live.evil.com'));
+    expect(resp).to.deep.equal([]);
+
+    resp = await externalActions.getAuthInfo({}, mockTab('https://main--helix-tools-website--adobe.aem.live.evil.com'));
+    expect(resp).to.deep.equal([]);
   });
 
   it('internal: addRemoveProject', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Restrict the origins for which the getAuthInfo external action will return meaningful information.
For the moment, it is just: labs.aem.live, tools.aem.live, aem.live, their edge delivery origin patterns and the development localhost. 

## Related Issue

Related to: https://github.com/adobe/aem-sidekick/issues/259

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests + installing the extension in the browser and testing with:
* A random AEM website, that's not trusted.
* Helix Labs
* localhost

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
