### PR TITLE
fix: show accurate activity message for config files

### DIFF
--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -610,6 +610,9 @@
     "unauthorized_state": {
       "message": "Account not authorized for this site"
     },
+    "config_state": {
+      "message": "Activating configuration..."
+    },
     "previewing_state": {
       "message": "Updating Preview..."
     },

--- a/src/extension/app/components/action-bar/activity-action/activity-action.js
+++ b/src/extension/app/components/action-bar/activity-action/activity-action.js
@@ -72,6 +72,7 @@ export class ActivityAction extends ConnectedElement {
       case STATE.PUBLISHNG:
       case STATE.UNPUBLISHING:
       case STATE.DELETING:
+      case STATE.CONFIG:
         return html`
           <sk-progress-circle size="s" indeterminate></sk-progress-circle><span>${this.appStore.i18n(this.appStore.state)}</span>
         `;

--- a/src/extension/app/constants.js
+++ b/src/extension/app/constants.js
@@ -105,6 +105,7 @@ export const STATE = {
   LOGGING_OUT: 'logging_out_state',
   UNAUTHORIZED: 'unauthorized_state',
   PREVIEWING: 'previewing_state',
+  CONFIG: 'config_state',
   BULK_PREVIEWING: 'bulk_previewing_state',
   PUBLISHNG: 'publishing_state',
   BULK_PUBLISHING: 'bulk_publishing_state',

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -917,7 +917,9 @@ export class AppStore {
     const { siteStore, status } = this;
     path = path || status.webPath;
 
-    this.setState(STATE.PREVIEWING);
+    this.setState(
+      path.startsWith('/.helix') ? STATE.CONFIG : STATE.PREVIEWING,
+    );
 
     // update preview
     const previewStatus = await this.api.updatePreview(path);
@@ -934,8 +936,6 @@ export class AppStore {
   }
 
   async updatePreview(ranBefore) {
-    this.setState(STATE.PREVIEWING);
-
     const res = await this.update();
     if (!res && !ranBefore) {
       // assume document has been renamed, re-fetch status and try again


### PR DESCRIPTION
Fix #363 