### PR TITLE
chore(test): less verbosity

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -34,6 +34,7 @@ export default {
       sourceMaps: 'inline',
     }),
   ],
+  browserLogs: false,
   testRunnerHtml: (testFramework) => `
   <html>
     <body>


### PR DESCRIPTION
Fix #351 

Browser logs can still be inspected by going into focus mode (F) and turning on browser debugging (D).