### PR TITLE
fix: apply the theme selected on sidekick to json view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/aem-sidekick",
-  "version": "7.1.4",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/aem-sidekick",
-      "version": "7.1.4",
+      "version": "7.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit/context": "1.1.3",

--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -85,6 +85,13 @@ export class JSONView extends LitElement {
   @property({ type: String })
   accessor url;
 
+   /**
+   * The selected theme from sidekick
+   * @type {string}
+   */
+   @property({ type: String })
+   accessor theme;
+
   /**
    * The selected tab index
    * @type {number}
@@ -103,7 +110,12 @@ export class JSONView extends LitElement {
 
     this.theme = await getConfig('local', 'theme') || 'light';
     document.body.setAttribute('color', this.theme);
-
+    chrome.storage.onChanged.addListener(async (changes, area) => {
+      if (area === 'local' && changes.theme?.newValue) {
+        this.theme = await getConfig('local', 'theme');
+        document.body.setAttribute('color', this.theme);
+      }
+    });
     const lang = getLanguage();
     this.languageDict = await fetchLanguageDict(undefined, lang);
 


### PR DESCRIPTION

## Description

Adding functionality to Json View to watch for the changes to theme config from sidekick and applying those to view when changed / toggled between "light" or "dark" theme.

## Related Issue

#383 

## Motivation and Context

There is an issue created #383 . Applying the same theme as sidekick to the json view makes sense so that the UI experience is better by making the view back ground matching the sidekick color

## How Has This Been Tested?

By installing the extension locally after building and tested both "preview" and "publish" urls of a sample ".json"

## Screenshots (if appropriate):

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
