### PR TITLE
fix : sidekick size and icon placements are not correct when JSON Vue extension available

### DIFF
--- a/src/extension/app/aem-sidekick.css.js
+++ b/src/extension/app/aem-sidekick.css.js
@@ -44,6 +44,7 @@ export const style = css`
     width: auto;
     min-width: 640px;
     max-width: var(--sidekick-max-width);
+    white-space:nowrap;
   }
 
   .aem-sk-special-view {

--- a/src/extension/app/components/action-bar/activity-action/activity-action.css.js
+++ b/src/extension/app/components/action-bar/activity-action/activity-action.css.js
@@ -55,6 +55,10 @@ export const style = css`
     flex-grow: 1;
   }
 
+  .toast-container .message > svg {
+    flex-shrink:0;
+  }
+
   .toast-container .actions {
     display: flex;
     align-items: center;

--- a/src/extension/app/components/action-bar/activity-action/activity-action.css.js
+++ b/src/extension/app/components/action-bar/activity-action/activity-action.css.js
@@ -45,6 +45,7 @@ export const style = css`
     align-items: center;
     flex-direction: row;
     width: 100%;
+    white-space: pre-wrap;
   }
 
   .toast-container .message {

--- a/src/extension/app/components/action-bar/activity-action/activity-action.css.js
+++ b/src/extension/app/components/action-bar/activity-action/activity-action.css.js
@@ -45,7 +45,6 @@ export const style = css`
     align-items: center;
     flex-direction: row;
     width: 100%;
-    white-space: pre-wrap;
   }
 
   .toast-container .message {
@@ -53,6 +52,10 @@ export const style = css`
     align-items: center;
     gap: 12px;
     flex-grow: 1;
+  }
+
+  .toast-container .message > span {
+    white-space:pre-wrap;
   }
 
   .toast-container .message > svg {

--- a/src/extension/app/components/onboarding/onboarding-dialog.css.js
+++ b/src/extension/app/components/onboarding/onboarding-dialog.css.js
@@ -17,6 +17,7 @@ export const style = css`
     color: var(--spectrum-gray-800);
     --mod-modal-background-color: transparent;
     --mod-tabs-start-to-edge: 20px;
+    white-space:initial;
   }
 
   sp-dialog-base {


### PR DESCRIPTION
If the sidekick installed along side of JSONVue extension , the sidekick action bar in json prev is not rendering correctly. 
Also when the white space css property is adjusted for action bar , the onboarding modal did not render correctly . The cross icon and other elements are not in place.

Sidekick
- Width is more
- Icons on action bar are not visible
Onboarding Modal 
- the cross icon is not accurately placed
- the onboarding modal window size is not correct 

## Description

Adjusting css property (white-space) for aem-sidekick and onboarding-dialog web components

## Related Issue

fix #422 

## Motivation and Context

JSONVue extension is used by almost 1 million users , so the chances of the this occurring is more even though it will not happen when the particular extension is not used along side of sidekick

## How Has This Been Tested?

Tested the sidekick fixes with or without JSONVue extension , so that it will work for both the instances
Tested the onboarding template in both Json and Doc preview modes
Tested the sidekick action bar with custom configuration by adding more than one type of plugins

## Screenshots (if appropriate):

With fixes in Desktop and Mobile break points
![image (27)](https://github.com/user-attachments/assets/8af36652-267d-48c6-a986-26a526f16b34)
![image (26)](https://github.com/user-attachments/assets/ee85906b-b3b1-466b-8068-27c0676948dc)

## Types of changes



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
