### PR TITLE
fix: search in multi sheet json - on search adding columns along with filtered data

### DIFF
--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -435,8 +435,8 @@ export class JSONView extends LitElement {
               .values(item).some((value) => value.toString().toLowerCase()
                 .includes(lowerCaseSearchString),
               ));
-
-            filteredData[sheetName] = { data: filteredSheetData ?? [] };
+            const { columns } = this.originalData[sheetName];
+            filteredData[sheetName] = { data: filteredSheetData ?? [], columns };
           }
         });
       } else {


### PR DESCRIPTION


## Description

Searching after entering any keyword in multi sheet was making the JSON view dis-appear and default to json data view.

## Related Issue

#421 

## Motivation and Context
Fixing the search functionality for multi sheet json . There were  some recent changes to view to accommodate header and body content alignment - https://github.com/adobe/aem-sidekick/pull/412  that needed change to include columns in to the sheet object on search

## How Has This Been Tested?

- Created a multi sheet 
- Previewed the json and tested the search functionality
- Created a single sheet
- Previewed and tested the search functionality

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
