### PR TITLE
fix: displaying the json content when sidekick is closed 

### DIFF
--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -1072,6 +1072,19 @@ export class AppStore {
           }
         }
       });
+      // handle side kick hide event
+      this.sidekick.addEventListener('hidden', () => {
+        [...this.sidekick.parentElement.children].forEach((el) => {
+          if (el !== this.sidekick) {
+            try {
+              // @ts-ignore
+              el.style.display = 'initial';
+            } catch (e) {
+              // ignore
+            }
+          }
+        });
+      });
     }
     return view;
   }

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -1072,7 +1072,7 @@ export class AppStore {
           }
         }
       });
-      // handle side kick hide event
+      // handle sidekick hide event
       this.sidekick.addEventListener('hidden', () => {
         [...this.sidekick.parentElement.children].forEach((el) => {
           if (el !== this.sidekick) {

--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -1072,19 +1072,6 @@ export class AppStore {
           }
         }
       });
-      // handle sidekick hide event
-      this.sidekick.addEventListener('hidden', () => {
-        [...this.sidekick.parentElement.children].forEach((el) => {
-          if (el !== this.sidekick) {
-            try {
-              // @ts-ignore
-              el.style.display = 'initial';
-            } catch (e) {
-              // ignore
-            }
-          }
-        });
-      });
     }
     return view;
   }

--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -44,7 +44,6 @@ function removeCacheParam(href = window.location.href) {
 
   const { getDisplay, toggleDisplay } = await import('./display.js');
   const display = await getDisplay();
-
   /**
    * Load the sidekick custom element and add it to the DOM
    * @param {OptionsConfig} config The config to load the sidekick with
@@ -75,7 +74,6 @@ function removeCacheParam(href = window.location.href) {
     sidekick.setAttribute('open', `${display}`);
     document.body.prepend(sidekick);
     window.hlx.sidekick = sidekick;
-
     // Listen for display toggle events from application
     sidekick.addEventListener('hidden', () => {
       toggleDisplay();
@@ -131,6 +129,18 @@ function removeCacheParam(href = window.location.href) {
       if (sidekick) {
         // Toggle sidekick display
         sidekick.setAttribute('open', `${display}`);
+        if (!display) {
+          [...sidekick.parentElement.children].forEach((el) => {
+            if (el !== sidekick) {
+              try {
+                // @ts-ignore
+                el.style.display = 'initial';
+              } catch (e) {
+                // ignore
+              }
+            }
+          });
+        }
       } else if (display) {
         // Load custom element polyfill
         await import('./lib/polyfills.min.js');

--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -129,9 +129,12 @@ function removeCacheParam(href = window.location.href) {
       if (sidekick) {
         // Toggle sidekick display
         sidekick.setAttribute('open', `${display}`);
-        if (!display) {
+        const hasCustomView = sidekick.shadowRoot.querySelector('.aem-sk-special-view');
+        if (!display && hasCustomView) {
           [...sidekick.parentElement.children].forEach((el) => {
-            if (el !== sidekick) {
+            if (el !== sidekick
+              && (el.hasAttribute('style')
+              && el.getAttribute('style') === 'display: none;')) {
               try {
                 // @ts-ignore
                 el.style.display = 'initial';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Listening to the sidekick "hidden" event to reset the display of json content from json view

## Related Issue

#428 

## Motivation and Context

Showing blank page when sidekick is closed while viewing json content is not a good user experience, rather resetting back to original json content is ideal.

## How Has This Been Tested?
After making the necessary code changes , built and used that extension to
- Test the intended functionality is not causing any regression for the page by testing "preview" , "live" web pages
- Tested on "preview" , "live" json views . Hiding sidekick will close json view and defaults to json content

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
