### PR TITLE
Converting Object to JSON Object to pass as event detail

### DIFF
--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -719,9 +719,10 @@ export class AppStore {
         },
         status,
       };
-      sidekick.dispatchEvent(new CustomEvent(name, {
-        detail: data,
-      }));
+      const event = new CustomEvent(name, {
+        detail: JSON.parse(JSON.stringify(data)),
+      });
+      sidekick.dispatchEvent(event);
       const userEvents = [
         'updated',
         'previewed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Passing an object without formatting it as JSON Object is not being transmitted as event detail object . 

## Related Issue

fix: #427 

## Motivation and Context

The additional event details are required to be passed along with events emitted by sidekick , so that they will be properly used in downstream as documented in [docs](https://www.aem.live/developer/sidekick-development#events) .

## How Has This Been Tested?

By converting the Object into JSON Object , so that the event detail parameter is in correct format

## Screenshots (if appropriate):

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
