### PR TITLE
fix: strings starting with // characters break preview of spreadsheet

### DIFF
--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -325,7 +325,7 @@ export class JSONView extends LitElement {
         valueContainer.classList.add('number');
         valueContainer.textContent = value;
       }
-    } else if (value.startsWith('/') || value.startsWith('http')) {
+    } else if (/\/^\/[a-z0-9]+$\/i/.test(value) || value.startsWith('http')) {
       // check if the value contains a glob pattern
       if (!value.includes('*')) {
         // assume link

--- a/test/fixtures/singlesheet.json
+++ b/test/fixtures/singlesheet.json
@@ -58,6 +58,20 @@
       "checkSum": 1234,
       "lastModified": "1642643576",
       "video": "/test/fixtures/video.mp4"
+    },
+    {
+      "date": "44582",
+      "image": "/test/fixtures/media_0000.png?width=1200&format=pjpg&optimize=medium",
+      "path": "/en/publish/2022/01/20/register-now-adobe-summit-2022-is-free-virtual-and-global",
+      "title": "//Register now: Adobe Summit 2022 is free, virtual, and global",
+      "author": "Adobe Events Team",
+      "description": "We’re less than eight weeks away from the start of Adobe Summit 2022 — and registration for this free, all-virtual event is officially open.",
+      "tags": "[\"Adobe Summit\",\"Insights & Inspiration\",\"Events\",\"Experience Cloud\",\"Digital Transformation\",\"UK\",\"APAC\"]",
+      "imageAlt": "Adobe Summit 2022.",
+      "robots": "0",
+      "checkSum": 1234,
+      "lastModified": "1642643576",
+      "video": "/test/fixtures/video.mp4"
     }
   ],
   ":type": "sheet"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Checking whether a string starting with single forward slash or not to be considered as relative url. Utilizing the regex instead of startsWith('/')

## Related Issue

#426 

## Motivation and Context

Issue created by QA team as sometimes the spread sheet may have strings starts with "//".

## How Has This Been Tested?

- created a spreadsheet with "//" 
- previewed the json
- make sure that json view does not break
- able to search for "//"

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
