### PR TITLE
fix: setting initial theme as dark for json view

### DIFF
--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -108,7 +108,7 @@ export class JSONView extends LitElement {
   async connectedCallback() {
     super.connectedCallback();
 
-    this.theme = await getConfig('local', 'theme') || 'light';
+    this.theme = await getConfig('local', 'theme') || 'dark';
     document.body.setAttribute('color', this.theme);
     chrome.storage.onChanged.addListener(async (changes, area) => {
       if (area === 'local' && changes.theme?.newValue) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Default theme for JSON View was "light" and changing that to "dark" which aligns with the default theme of the side kick.

## Related Issue

Fix #442 

## Motivation and Context

Keeps the JSON view initial background theme inline with the sidekick theme

## How Has This Been Tested?

- Built and Installed the sidekick extension in a chrome browser , after making the code changes
- Manually  tested , validated that the initial theme is dark
- Toggled the theme on sidekick , which is applied for the json view as expectd

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
