### PR TITLE
fix: ensure every project match has an id

### DIFF
--- a/src/extension/project.js
+++ b/src/extension/project.js
@@ -519,6 +519,8 @@ export async function getProjectMatches(configs, tab) {
     }
   }
   return matches
+    // ensure each match has an id
+    .map((cfg) => (cfg.id ? cfg : { ...cfg, id: `${cfg.owner}/${cfg.repo}` }))
     // exclude disabled configs
     .filter(({ owner, repo }) => !configs
       .find((cfg) => cfg.owner === owner && cfg.repo === repo && cfg.disabled));

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -389,7 +389,9 @@ describe('Test project', () => {
     mockDiscoveryCall({ multipleOriginalSites: true });
     const tab = mockTab('https://foo.sharepoint.com/something/boo/Shared%20Documents/root1');
     await urlCache.set(tab);
-    expect((await getProjectMatches([], tab)).length).to.equal(2);
+    const matches = await getProjectMatches([], tab);
+    expect(matches.length).to.equal(2);
+    expect(matches[0].id).to.equal('foo/bar1');
   }).timeout(5000);
 
   it('getGitHubSettings', async () => {


### PR DESCRIPTION
# v7.2.3 Release Notes

## Bug Fixes
- Multiple project matches no longer lead to empty picker buttons

## Resolved Issues
- Fixes #449 