### PR TITLE
feat: allow tools.aem.live and labs.aem.live to list configured sites

### DIFF
--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -138,7 +138,7 @@ function isTrustedOrigin(origin) {
  * Returns the organizations the user is currently authenticated for.
  * @returns {Promise<string[]>} The organizations
  */
-async function getAuthInfo(message, sender) {
+async function getAuthInfo(_, sender) {
   const { origin } = new URL(sender.url);
 
   if (!isTrustedOrigin(origin)) {
@@ -155,14 +155,18 @@ async function getAuthInfo(message, sender) {
  * Returns the configured sites.
  * @returns {Promise<Object[]>} The sites
  */
-async function getSites(message, sender) {
+async function getSites(_, sender) {
   const { origin } = new URL(sender.url);
 
   if (!isTrustedOrigin(origin)) {
     return []; // don't give out any information
   }
 
-  return await getConfig('sync', 'projects') || [];
+  return (await getConfig('sync', 'projects') || [])
+    .map((handle) => {
+      const [org, site] = handle.split('/');
+      return { org, site };
+    });
 }
 
 /**

--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -110,7 +110,7 @@ export async function showSidekickNotification(tabId, data, callback) {
  * @param {string} origin
  * @returns {boolean} true - trusted / false - untrusted
  */
-function isGetAuthInfoTrustedOrigin(origin) {
+function isTrustedOrigin(origin) {
   const TRUSTED_ORIGINS = [
     ADMIN_ORIGIN,
     'https://labs.aem.live',
@@ -141,7 +141,7 @@ function isGetAuthInfoTrustedOrigin(origin) {
 async function getAuthInfo(message, sender) {
   const { origin } = new URL(sender.url);
 
-  if (!isGetAuthInfoTrustedOrigin(origin)) {
+  if (!isTrustedOrigin(origin)) {
     return []; // don't give out any information
   }
 
@@ -149,6 +149,20 @@ async function getAuthInfo(message, sender) {
   return projects
     .filter(({ authToken, authTokenExpiry }) => !!authToken && authTokenExpiry > Date.now() / 1000)
     .map(({ owner }) => owner);
+}
+
+/**
+ * Returns the configured sites.
+ * @returns {Promise<Object[]>} The sites
+ */
+async function getSites(message, sender) {
+  const { origin } = new URL(sender.url);
+
+  if (!isTrustedOrigin(origin)) {
+    return []; // don't give out any information
+  }
+
+  return await getConfig('sync', 'projects') || [];
 }
 
 /**
@@ -306,4 +320,5 @@ export const internalActions = {
 export const externalActions = {
   updateAuthToken,
   getAuthInfo,
+  getSites,
 };

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -156,6 +156,49 @@ describe('Test actions', () => {
     expect(resp).to.deep.equal([]);
   });
 
+  it('external: getSites', async () => {
+    const getStub = sandbox.stub(chrome.storage.sync, 'get');
+    const projects = [
+      'foo/bar',
+      'foo1/baz',
+      'foo2/baz',
+    ];
+    let resp;
+
+    // without projects
+    getStub.resolves({});
+    resp = await externalActions.getSites({}, mockTab('https://tools.aem.live'));
+    expect(resp).to.deep.equal([]);
+
+    // with auth info
+    getStub.resolves({
+      projects,
+    });
+
+    // trusted actors
+    resp = await externalActions.getSites({}, mockTab('https://tools.aem.live/foo'));
+    expect(resp).to.deep.equal(projects);
+
+    resp = await externalActions.getSites({}, mockTab('https://labs.aem.live/foo'));
+    expect(resp).to.deep.equal(projects);
+
+    resp = await externalActions.getSites({}, mockTab('https://feature--helix-labs-website--adobe.aem.page/feature'));
+    expect(resp).to.deep.equal(projects);
+
+    // untrusted actors
+    resp = await externalActions.getSites({}, mockTab('https://evil.live'));
+    expect(resp).to.deep.equal([]);
+
+    resp = await externalActions.getSites({}, mockTab('https://main--site--owner.aem.live'));
+    expect(resp).to.deep.equal([]);
+
+    resp = await externalActions.getSites({}, mockTab('https://tools.aem.live.evil.com'));
+    expect(resp).to.deep.equal([]);
+
+    resp = await externalActions.getSites({}, mockTab('https://main--helix-tools-website--adobe-evl.aem.live'));
+    expect(resp).to.deep.equal([]);
+  });
+
   it('internal: addRemoveProject', async () => {
     const set = sandbox.spy(chrome.storage.sync, 'set');
     const remove = sandbox.spy(chrome.storage.sync, 'remove');

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -163,6 +163,12 @@ describe('Test actions', () => {
       'foo1/baz',
       'foo2/baz',
     ];
+    const expectedOutput = [
+      { org: 'foo', site: 'bar' },
+      { org: 'foo1', site: 'baz' },
+      { org: 'foo2', site: 'baz' },
+    ];
+
     let resp;
 
     // without projects
@@ -177,13 +183,13 @@ describe('Test actions', () => {
 
     // trusted actors
     resp = await externalActions.getSites({}, mockTab('https://tools.aem.live/foo'));
-    expect(resp).to.deep.equal(projects);
+    expect(resp).to.deep.equal(expectedOutput);
 
     resp = await externalActions.getSites({}, mockTab('https://labs.aem.live/foo'));
-    expect(resp).to.deep.equal(projects);
+    expect(resp).to.deep.equal(expectedOutput);
 
     resp = await externalActions.getSites({}, mockTab('https://feature--helix-labs-website--adobe.aem.page/feature'));
-    expect(resp).to.deep.equal(projects);
+    expect(resp).to.deep.equal(expectedOutput);
 
     // untrusted actors
     resp = await externalActions.getSites({}, mockTab('https://evil.live'));


### PR DESCRIPTION
Fix #459 