### PR TITLE
fix: close button overhang

### DIFF
--- a/src/extension/app/spectrum-2.css.js
+++ b/src/extension/app/spectrum-2.css.js
@@ -97,7 +97,7 @@ export const spectrum2 = css`
     --spectrum2-background-color-hover-dark: rgba(255, 255, 255, 0.05);
 
     /* Sidekick theme tokens */
-    --sidekick-max-width: 800px;
+    --sidekick-max-width: 805px;
     --sidekick-color-light: #292929;
     --sidekick-color-dark: #DBDBDB;
     --sidekick-background-light: #FFFFFFCC;


### PR DESCRIPTION
Fix #472 

Quick fix: add 5px to `--sidekick-max-width`