### PR TITLE
fix: support newer sharepoint structure

### DIFF
--- a/src/extension/app/store/bulk.js
+++ b/src/extension/app/store/bulk.js
@@ -156,7 +156,7 @@ export class BulkStore {
    * @returns {BulkSelection} The selection
    */
   #getSharepointBulkSelection(document) {
-    return [...document.querySelectorAll('#appRoot [role="presentation"] div[aria-selected="true"]')]
+    return [...document.querySelectorAll('#appRoot [aria-selected="true"]:not([aria-checked="true"]')]
       // exclude folders
       .filter((row) => !row.querySelector('img')?.getAttribute('src').includes('/foldericons/')
         && !row.querySelector('img')?.getAttribute('src').endsWith('folder.svg')
@@ -164,9 +164,15 @@ export class BulkStore {
       // extract file name and type
       .map((row) => {
         const info = row.getAttribute('aria-label') || row.querySelector('span')?.textContent;
+
         // info format: bla.docx, docx File, Private, Modified 8/28/2023, edited by Jane, 1 KB
-        const type = info.match(/, ([\p{L}\p{N}]+) [\p{L}\p{N}]+,/u)?.[1];
-        const file = type && info.split(`, ${type}`)[0];
+        let type = info.match(/, ([\p{L}\p{N}]+) [\p{L}\p{N}]+,/u)?.[1];
+        let file = type && info.split(`, ${type}`)[0];
+
+        if (!type) {
+          type = info.split('.').pop();
+          file = info;
+        }
         return {
           file,
           type,

--- a/test/app/store/bulk.test.js
+++ b/test/app/store/bulk.test.js
@@ -102,6 +102,32 @@ describe('Test Bulk Store', () => {
         });
       });
 
+      const testFn = adminEnv === HelixMockContentSources.SHAREPOINT ? describe : describe.skip;
+      testFn(`selection in ${adminEnv} (newer sharepoint admin view)`, () => {
+        beforeEach(async () => {
+          sidekickTest.mockAdminDOM(adminEnv, 'new-sharepoint-list');
+        });
+
+        it('has empty selection when initialized', async () => {
+          bulkStore.initStore(appStore.location);
+          expect(bulkStore.selection.length).to.equal(0);
+        });
+
+        it('uses existing selection when initialized', async () => {
+          sidekickTest.toggleAdminItems(['document']);
+          bulkStore.initStore(appStore.location);
+          await waitUntil(() => bulkStore.selection.length === 1);
+        });
+
+        it('updates initial selection when user toggles files', async () => {
+          bulkStore.initStore(appStore.location);
+          expect(bulkStore.selection.length).to.equal(0);
+
+          sidekickTest.toggleAdminItems(['document']);
+          await waitUntil(() => bulkStore.selection.length === 1);
+        });
+      });
+
       describe(`selection in ${adminEnv} (grid)`, () => {
         beforeEach(async () => {
           sidekickTest.mockAdminDOM(adminEnv, 'grid');

--- a/test/fixtures/content-sources.js
+++ b/test/fixtures/content-sources.js
@@ -216,16 +216,17 @@ export function mockSharePointFile({ path, type }, viewType = 'list', nonLatin =
   const descriptor = spDescriptors[type];
   const filename = path.split('/').pop();
 
-  let fileInfo = nonLatin
-    ? `${filename}, ${descriptor} 文件, 专用, 已于 2/6/2023 修改, 编辑者: John Doe, 365 KB`
-    : `${filename}, ${descriptor} File, Private, Modified 4/9/2023, edited by John Doe, 356 KB`;
-
-  const newSharepointList = viewType === 'new-sharepoint-list';
-  if (newSharepointList) {
+  let fileInfo;
+  const isNewSharepointList = viewType === 'new-sharepoint-list';
+  if (isNewSharepointList) {
     fileInfo = filename;
+  } else {
+    fileInfo = nonLatin
+      ? `${filename}, ${descriptor} 文件, 专用, 已于 2/6/2023 修改, 编辑者: John Doe, 365 KB`
+      : `${filename}, ${descriptor} File, Private, Modified 4/9/2023, edited by John Doe, 356 KB`;
   }
 
-  const result = viewType === 'list' || newSharepointList ? `
+  const result = viewType === 'list' || isNewSharepointList ? `
     <div class="file" id="file-${type}" role="row" aria-selected="false"
       aria-label="${fileInfo}">
       <img src="./icons/${type}.svg">

--- a/test/fixtures/content-sources.js
+++ b/test/fixtures/content-sources.js
@@ -216,11 +216,16 @@ export function mockSharePointFile({ path, type }, viewType = 'list', nonLatin =
   const descriptor = spDescriptors[type];
   const filename = path.split('/').pop();
 
-  const fileInfo = nonLatin
+  let fileInfo = nonLatin
     ? `${filename}, ${descriptor} 文件, 专用, 已于 2/6/2023 修改, 编辑者: John Doe, 365 KB`
     : `${filename}, ${descriptor} File, Private, Modified 4/9/2023, edited by John Doe, 356 KB`;
 
-  const result = viewType === 'list' ? `
+  const newSharepointList = viewType === 'new-sharepoint-list';
+  if (newSharepointList) {
+    fileInfo = filename;
+  }
+
+  const result = viewType === 'list' || newSharepointList ? `
     <div class="file" id="file-${type}" role="row" aria-selected="false"
       aria-label="${fileInfo}">
       <img src="./icons/${type}.svg">


### PR DESCRIPTION
fixes: #488 

Older sharepoint DOM had the following `aria-label` on the selected elements
`bla.docx, docx File, Private, Modified 8/28/2023, edited by Jane, 1 KB`

The newer design just has `bla.docx`. 