### PR TITLE
fix: Do not inject admin token for requests originating on da.live

### DIFF
--- a/src/extension/auth.js
+++ b/src/extension/auth.js
@@ -54,6 +54,7 @@ export async function configureAuthAndCorsHeaders() {
             }],
           },
           condition: {
+            excludedInitiatorDomains: ['da.live'],
             regexFilter: `^https://${adminHost}/(config/${owner}.json|[a-z]+/${owner}/.*)`,
             requestDomains: [adminHost],
             requestMethods: ['get', 'post', 'delete'],

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -97,6 +97,7 @@ describe('Test auth', () => {
             ],
           },
           condition: {
+            excludedInitiatorDomains: ['da.live'],
             regexFilter: '^https://admin.hlx.page/(config/test.json|[a-z]+/test/.*)',
             requestDomains: [
               'admin.hlx.page',
@@ -179,6 +180,7 @@ describe('Test auth', () => {
             ],
           },
           condition: {
+            excludedInitiatorDomains: ['da.live'],
             regexFilter: '^https://admin.hlx.page/(config/test.json|[a-z]+/test/.*)',
             requestDomains: [
               'admin.hlx.page',
@@ -336,6 +338,7 @@ describe('Test auth', () => {
             ],
           },
           condition: {
+            excludedInitiatorDomains: ['da.live'],
             regexFilter: '^https://admin.hlx.page/(config/test.json|[a-z]+/test/.*)',
             requestDomains: [
               'admin.hlx.page',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Discussed with @auniverseaway 
Since users login into DA and DA is sending its own authentication header, the sidekick should not be trying to inject its own here.
In some cases, it can give confusing errors. E.g. there is a mismatch in the IMS org selected during login between sidekick and DA.
The way that chrome works is that this also applies to subdomains of `da.live`.
Will have to see if in the future this may cause problems.
 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually in the browser.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
