### PR TITLE
fix: json view bug fixes

### DIFF
--- a/src/extension/_locales/zh_CN/messages.json
+++ b/src/extension/_locales/zh_CN/messages.json
@@ -471,7 +471,7 @@
     "message": "从未发布"
   },
   "loading_diff": {
-    "message": "正在加载更改……"
+    "message": "正在加载更改…"
   },
   "logging_in_state": {
     "message": "正在登录……"

--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -763,7 +763,24 @@ export class JSONView extends LitElement {
           this.originalDiffData = this.diffData;
         } else if (liveRes.status === 404) {
           // If live version doesn't exist yet, treat it as empty
-          this.liveData = { data: [], columns: this.originalData.columns };
+          // Create a proper fallback structure that matches the original data
+          if (this.originalData[':type'] === 'multi-sheet' && this.originalData[':names']) {
+            // Handle multi-sheet case
+            this.liveData = { ...this.originalData };
+            this.liveData[':names'].forEach((name) => {
+              if (this.liveData[name]) {
+                this.liveData[name] = { ...this.liveData[name] };
+                this.liveData[name].data = [];
+              }
+            });
+          } else {
+            // Handle single sheet case
+            this.liveData = {
+              data: [],
+              columns: this.originalData.columns || [],
+              total: 0,
+            };
+          }
           if (previewTotal > DEFAULT_BATCH_SIZE) {
             this.originalData = await this.fetchAllItems(this.url, previewTotal);
           }

--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -404,7 +404,7 @@ export class JSONView extends LitElement {
         valueContainer.classList.add('number');
         valueContainer.textContent = value;
       }
-    } else if (/^\/[a-z0-9]+/i.test(value) || value.startsWith('http')) {
+    } else if (!Array.isArray(value) && (/^\/[a-z0-9]+/i.test(value) || value.startsWith('http'))) {
       // check if the value contains a glob pattern
       if (!value.includes('*')) {
         // assume link
@@ -433,7 +433,7 @@ export class JSONView extends LitElement {
         // Text
         valueContainer.textContent = value;
       }
-    } else if (value.startsWith('[') && value.endsWith(']')) {
+    } else if (Array.isArray(value) || (typeof value === 'string' && value.startsWith('[') && value.endsWith(']'))) {
       // assume array
       valueContainer.classList.add('list');
       const list = valueContainer.appendChild(document.createElement('ul'));

--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -433,18 +433,30 @@ export class JSONView extends LitElement {
         // Text
         valueContainer.textContent = value;
       }
-    } else if (Array.isArray(value) || (typeof value === 'string' && value.startsWith('[') && value.endsWith(']'))) {
-      // assume array
+    } else if (!Array.isArray(value) && value.startsWith('[') && value.endsWith(']')) {
       valueContainer.classList.add('list');
       const list = valueContainer.appendChild(document.createElement('ul'));
       JSON.parse(value).forEach((v) => {
         const item = list.appendChild(document.createElement('li'));
         item.textContent = v;
       });
+    } else if (Array.isArray(value)) {
+      // assume array
+      valueContainer.classList.add('list');
+      const list = valueContainer.appendChild(document.createElement('ul'));
+      value.forEach((v) => {
+        const values = v.split(',');
+        values.forEach((val) => {
+          const item = list.appendChild(document.createElement('li'));
+          const valueItem = item.appendChild(document.createElement('div'));
+          valueItem.textContent = val.trim();
+        });
+      });
     } else {
       // text
       valueContainer.textContent = value;
     }
+
     // check if the value contains any rtl characters
     if (/[\u0590-\u06FF]/.test(valueContainer.textContent)) {
       dir = 'rtl';

--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -287,13 +287,15 @@ export class JSONView extends LitElement {
             <sp-action-button value=${index.toString()} .selected=${index === this.selectedTabIndex}>${name}</sp-action-button>
           `)}
         </sp-action-group>
-        <div class="stats">
+        ${total > 0 ? html`
+          <div class="stats">
           ${this.diffMode ? html`
             <p>${i18n(this.languageDict, 'json_results_stat').replace('$1', diffFilteredCount).replace('$2', total)}</p>
           ` : html`
             <p>${i18n(this.languageDict, 'json_results_stat').replace('$1', filteredCount).replace('$2', total)}</p>
           `}
         </div>
+        ` : ''}
         <sp-action-group>
           ${this.url.includes('.page') ? html`
             ${this.diffMode ? html`


### PR DESCRIPTION
## Description
- Check if the value we want to format is an Array and format accordingly
- Hide results count in JSON view if not present in JSON data
- Fix toggle view issue when there are multiple sheets and the json hasn't been published yet

## Related Issues
https://github.com/adobe/aem-sidekick/issues/648
https://github.com/adobe/aem-sidekick/issues/520
https://github.com/adobe/aem-sidekick/issues/617

## Motivation and Context

Helix JSON (found in query-index.json commonly) can have arrays in the values for each column. We don't have a case for that currently which breaks the json view.
Hide results count if original json doesn't have the total
When live json 404s, check if multi sheet and set up a dummy json without data so that the show changes still works

## How Has This Been Tested?

Tested the links from the slack thread to make sure it works well

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
