### PR TITLE
Login handle 403

### DIFF
--- a/src/extension/app/components/plugin/login/login.js
+++ b/src/extension/app/components/plugin/login/login.js
@@ -176,7 +176,8 @@ export class LoginButton extends ConnectedElement {
     const { profile } = this.appStore.status;
     const authenticated = this.appStore.isAuthenticated();
 
-    if ((!this.appStore.status.webPath && this.appStore.status?.status !== 401)
+    if ((!this.appStore.status.webPath
+      && this.appStore.status?.status !== 401 && this.appStore.status?.status !== 403)
       || this.appStore.state === STATE.LOGGING_IN
       || this.appStore.state === STATE.LOGGING_OUT) {
       return html`
@@ -186,8 +187,25 @@ export class LoginButton extends ConnectedElement {
       `;
     }
 
-    if (!authenticated) {
+    if (!authenticated && this.appStore.status?.status !== 403) {
       return html`<sp-action-button quiet class="login" @click=${this.login}>${this.appStore.i18n('user_login')}</sp-action-button>`;
+    } else if (!authenticated && this.appStore.status?.status === 403) {
+      return html`
+      <sp-action-menu
+        placement="top"
+        quiet
+      >
+        <sp-icon slot="icon" size="l">
+          ${ICONS.USER_ICON}
+        </sp-icon>
+        <sk-menu-item class="logout" value="logout" @click=${this.logout} tabindex="0">
+          <sp-icon slot="icon" size="xl">
+            ${ICONS.SIGN_OUT}
+          </sp-icon>
+          ${this.appStore.i18n('user_logout')}
+        </sk-menu-item>
+      </sp-action-menu>
+    `;
     } else {
       return html`
         <sp-action-menu

--- a/src/extension/app/components/plugin/login/login.js
+++ b/src/extension/app/components/plugin/login/login.js
@@ -189,23 +189,6 @@ export class LoginButton extends ConnectedElement {
 
     if (!authenticated && this.appStore.status?.status !== 403) {
       return html`<sp-action-button quiet class="login" @click=${this.login}>${this.appStore.i18n('user_login')}</sp-action-button>`;
-    } else if (!authenticated && this.appStore.status?.status === 403) {
-      return html`
-      <sp-action-menu
-        placement="top"
-        quiet
-      >
-        <sp-icon slot="icon" size="l">
-          ${ICONS.USER_ICON}
-        </sp-icon>
-        <sk-menu-item class="logout" value="logout" @click=${this.logout} tabindex="0">
-          <sp-icon slot="icon" size="xl">
-            ${ICONS.SIGN_OUT}
-          </sp-icon>
-          ${this.appStore.i18n('user_logout')}
-        </sk-menu-item>
-      </sp-action-menu>
-    `;
     } else {
       return html`
         <sp-action-menu
@@ -215,12 +198,14 @@ export class LoginButton extends ConnectedElement {
           <sp-icon slot="icon" size="l" class=${ifDefined(this.profilePicture ? 'picture' : undefined)}>
             ${this.profilePicture ? html`<img src=${this.profilePicture} alt=${profile.name} />` : html`${ICONS.USER_ICON}`}
           </sp-icon>
+          ${profile && profile.name && profile.email ? html`
           <sk-menu-item class="user" value="user" tabindex="-1" disabled>
             ${this.profilePicture ? html`<img src=${this.profilePicture} slot="icon" alt=${profile.name} />` : html`<div class="no-picture" slot="icon">${ICONS.USER_ICON}</div>`}
             ${profile.name}
             <span slot="description">${profile.email}</span>
           </sk-menu-item>
           <sp-divider size="s"></sp-divider>
+          ` : ''}
           <sk-menu-item class="logout" value="logout" @click=${this.logout} tabindex="0">
             <sp-icon slot="icon" size="xl">
               ${ICONS.SIGN_OUT}


### PR DESCRIPTION
## Description

Changes login component so when the config call returns 403, user is able to logout. 

Note: in the original issues I talked about different auth sources, but I don't think that matters. I think the root cause is that the sidekick stores and injects the auth token based on the org, but different sites within that org could allow/disallow different sets users. 

I ran into it is because on one site I logged in using my @adobe.com account, but on the other site, access was only allowed for my personal @gmail.com account. I don't think it matters that these use different auth providers, just that they are different accounts/email addresses within a single org. I think the same thing would happen if a single person logged into one site as name@company.com but wanted to log into another site as admin@company.com (or similar).

It's probably an edge case, in most cases, for a single org, I'd expect users to have a single profile/address. But I think/hope the fix is valid as 403 should indicate the user is logged in but lacks permissions, so letting them logout should be valid.

## Related Issue

Fix #651 

## Motivation and Context


## How Has This Been Tested?

installed sidekick locally and tested, plus added test to login.test.js

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
