### PR TITLE
fix: remove site api to support org/site

### DIFF
--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -240,7 +240,10 @@ async function removeSite({ config }, { tab }) {
   const owner = config.owner || config.org;
   const repo = config.repo || config.site;
   if (owner && repo) {
-    return deleteProject(config);
+    return deleteProject({
+      owner,
+      repo,
+    });
   } else {
     log.warn('removeSite: missing required parameters org (or owner) and site (or repo)');
     return false;


### PR DESCRIPTION
External API:  to match `addSite`, `removeSite` should also accept both `owner/repo` and `org/site`.