### PR TITLE
fix: updated json view to handle missing columns key in the OOTB json

### DIFF
--- a/src/extension/views/json/json.js
+++ b/src/extension/views/json/json.js
@@ -226,14 +226,14 @@ export class JSONView extends LitElement {
     const multiSheet = json[':type'] === 'multi-sheet' && json[':names'];
     if (multiSheet) {
       json[':names'].forEach((name) => {
-        const { data, columns } = json[name];
-        if (data && columns) {
+        const { data } = json[name];
+        if (data) {
           sheets[name] = json[name];
         }
       });
     } else {
-      const { data, columns } = json;
-      if (data && columns) {
+      const { data } = json;
+      if (data) {
         sheets['shared-default'] = json;
       }
     }
@@ -318,8 +318,8 @@ export class JSONView extends LitElement {
     if (names.length > 0) {
       const name = names[this.selectedTabIndex];
       const sheet = sheets[name];
-      const { data, columns } = sheet;
-      elements.push(this.renderTable(data, columns, url));
+      const { data } = sheet;
+      elements.push(this.renderTable(data, url));
     }
     return elements;
   }
@@ -511,11 +511,11 @@ export class JSONView extends LitElement {
   /**
    * Render the table
    * @param {Object[]} rows The rows to render
-   * @param {string[]} headers The header names
    * @param {string} url The url of the json file
    * @returns {TemplateResult} The rendered table
    */
-  renderTable(rows, headers, url) {
+  renderTable(rows, url) {
+    const headers = rows.length > 0 ? Object.keys(rows[0]) : [];
     if (rows.length === 0) {
       if (this.filterText) {
         return this.renderEmptyState('no_results');


### PR DESCRIPTION

## Description

OOTB json from helix no longer has the `columns` key that this json view was depending on.
## Related Issue

Fix: #670 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
