### PR TITLE
fix(env-switcher): source label always falls back on contentSourceType

### DIFF
--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -663,14 +663,18 @@ export class AppStore {
     const { contentSourceType, contentSourceEditLabel } = this.siteStore;
     const { preview: { sourceLocation } = {} } = this.status;
 
-    if (sourceLocation?.startsWith('onedrive:') || contentSourceType === 'onedrive') {
+    if (sourceLocation?.startsWith('onedrive:')) {
       return 'SharePoint';
-    } else if (sourceLocation?.startsWith('gdrive:') || contentSourceType === 'google') {
+    } else if (sourceLocation?.startsWith('gdrive:')) {
       return 'Google Drive';
-    } else if (contentSourceEditLabel) {
-      return contentSourceEditLabel;
+    } else if (sourceLocation?.startsWith('markup:')) {
+      return contentSourceEditLabel || 'BYOM';
+    } else if (contentSourceType === 'onedrive') {
+      return 'SharePoint';
+    } else if (contentSourceType === 'google') {
+      return 'Google Drive';
     } else {
-      return 'BYOM';
+      return contentSourceEditLabel || 'BYOM';
     }
   }
 

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -2003,12 +2003,20 @@ describe('Test App Store', () => {
       expect(instance.getContentSourceLabel()).to.equal('Document Authoring');
     });
 
-    it('should return "BYOM" for everything else', () => {
+    it('should return "BYOM" if no label is provided', () => {
       instance.status = {
         preview: {
           sourceLocation: 'markup:foo',
         },
       };
+      expect(instance.getContentSourceLabel()).to.equal('BYOM');
+    });
+
+    it('should return "BYOM" for everything else', () => {
+      instance.status = {
+        preview: { status: 404 },
+      };
+      instance.siteStore.contentSourceType = 'unknown';
       expect(instance.getContentSourceLabel()).to.equal('BYOM');
     });
   });


### PR DESCRIPTION
Fix #688 