### PR TITLE
Allow localhost URLs with specific port in auth allowed origins regex filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,6 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1173,7 +1172,6 @@
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -3737,7 +3735,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -4598,7 +4595,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5105,6 +5101,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.7.0.tgz",
+      "integrity": "sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/bare-fs": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.1.tgz",
@@ -5275,7 +5279,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -6787,8 +6790,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1402036.tgz",
       "integrity": "sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -7601,7 +7603,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7762,7 +7763,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -11992,7 +11992,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15697,7 +15696,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17645,7 +17643,6 @@
       "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17940,7 +17937,6 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -18004,6 +18000,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/semantic-release-discord-bot/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/semantic-release-discord-bot/node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -18021,6 +18044,7 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -18061,6 +18085,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -18075,6 +18100,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },

--- a/src/extension/auth.js
+++ b/src/extension/auth.js
@@ -109,7 +109,7 @@ export async function configureAuthAndCorsHeaders() {
             }],
           },
           condition: {
-            regexFilter: `^https://[a-z0-9-]+--${repo}--${owner}\\.aem\\.(page|live|reviews)/.*`,
+            regexFilter: `^(https://[a-z0-9-]+--${repo}--${owner}\\.aem\\.(page|live|reviews)/.*|http://localhost:[0-9]+/.*)`,
             requestMethods: ['get', 'post'],
             resourceTypes: [
               'main_frame',

--- a/src/extension/auth.js
+++ b/src/extension/auth.js
@@ -109,7 +109,7 @@ export async function configureAuthAndCorsHeaders() {
             }],
           },
           condition: {
-            regexFilter: `^(https://[a-z0-9-]+--${repo}--${owner}\\.aem\\.(page|live|reviews)/.*|http://localhost:[0-9]+/.*)`,
+            regexFilter: `^(https://[a-z0-9-]+--${repo}--${owner}\\.aem\\.(page|live|reviews)/.*|http://localhost:3000/.*)`,
             requestMethods: ['get', 'post'],
             resourceTypes: [
               'main_frame',

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -401,7 +401,7 @@ describe('Test auth', () => {
             ],
           },
           condition: {
-            regexFilter: '^https://[a-z0-9-]+--site--test\\.aem\\.(page|live|reviews)/.*',
+            regexFilter: '^(https://[a-z0-9-]+--site--test\\.aem\\.(page|live|reviews)/.*|http://localhost:[0-9]+/.*)',
             requestMethods: [
               'get',
               'post',

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -401,7 +401,29 @@ describe('Test auth', () => {
             ],
           },
           condition: {
-            regexFilter: '^(https://[a-z0-9-]+--site--test\\.aem\\.(page|live|reviews)/.*|http://localhost:[0-9]+/.*)',
+            regexFilter: sinon.match((value) => {
+              const regex = new RegExp(value);
+              // Should match aem.page, aem.live, and aem.reviews URLs
+              const shouldMatch = [
+                'https://main--site--test.aem.page/index.html',
+                'https://preview--site--test.aem.live/document.html',
+                'https://feature-branch--site--test.aem.reviews/test.html',
+                // Should match localhost with various ports
+                'http://localhost:3000/',
+                'http://localhost:3000/index.html',
+                'http://localhost:8080/path/to/file.html',
+                'http://localhost:65535/test',
+              ];
+              const shouldNotMatch = [
+                'https://example.com/',
+                'http://localhost/', // no port
+                'https://localhost:3000/', // https instead of http
+                'http://127.0.0.1:3000/', // IP instead of localhost
+                'http://localhost:3000', // no trailing slash
+              ];
+              return shouldMatch.every((url) => regex.test(url))
+                && shouldNotMatch.every((url) => !regex.test(url));
+            }),
             requestMethods: [
               'get',
               'post',

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -405,18 +405,18 @@ describe('Test auth', () => {
               const regex = new RegExp(value);
               // Should match aem.page, aem.live, and aem.reviews URLs
               const shouldMatch = [
-                'https://main--site--test.aem.page/index.html',
-                'https://preview--site--test.aem.live/document.html',
-                'https://feature-branch--site--test.aem.reviews/test.html',
-                // Should match localhost with various ports
+                'https://main--site--test.aem.page/',
+                'https://main--site--test.aem.page/index',
+                'https://preview--site--test.aem.live/document',
+                'https://feature-branch--site--test.aem.reviews/test',
+                // Should match localhost:3000
                 'http://localhost:3000/',
-                'http://localhost:3000/index.html',
-                'http://localhost:8080/path/to/file.html',
-                'http://localhost:65535/test',
+                'http://localhost:3000/index',
               ];
               const shouldNotMatch = [
                 'https://example.com/',
                 'http://localhost/', // no port
+                'http://localhost:8080/', // different port
                 'https://localhost:3000/', // https instead of http
                 'http://127.0.0.1:3000/', // IP instead of localhost
                 'http://localhost:3000', // no trailing slash


### PR DESCRIPTION
## Summary
- Expands the authentication allowed origins to include `http://localhost` URLs with a port specifically set to 3000
- Enables development and testing environments using `http://localhost:3000`

## Changes

### Auth Configuration
- Modified the `regexFilter` in `configureAuthAndCorsHeaders`:
  - Previous regex only matched URLs of the form:
    `https://[subdomain]--[repo]--[owner].aem.(page|live|reviews)/...`
  - Updated regex now also accepts:
    `http://localhost:3000/` with the specific port 3000 (other ports are not matched)

### Tests
- Enhanced the auth tests to verify the regex matches the expected URLs including `http://localhost:3000` and rejects variants like `http://localhost/` (no port), `http://localhost:8080/` (different port), and similar non-matching URLs

## Test plan
- [x] Verify requests from `http://localhost:3000` pass authentication checks
- [x] Confirm existing URLs for production/staging still match correctly
- [x] Run existing auth and CORS header tests to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/59611b9f-e593-4499-a643-ccf1a8ec0764