### PR TITLE
move project admin link to tools as part of migration

### DIFF
--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -425,7 +425,7 @@ async function importProjects(tab) {
  */
 async function manageProjects(tab) {
   await chrome.tabs.create({
-    url: 'https://labs.aem.live/tools/project-admin/index.html',
+    url: 'https://tools.aem.live/tools/project-admin/index.html',
     openerTabId: tab.id,
     windowId: tab.windowId,
   });

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -815,7 +815,7 @@ describe('Test actions', () => {
       id: 2,
     }));
     expect(createSpy.calledWithMatch({
-      url: 'https://labs.aem.live/tools/project-admin/index.html',
+      url: 'https://tools.aem.live/tools/project-admin/index.html',
       openerTabId: 2,
       windowId: 0,
     })).to.be.true;


### PR DESCRIPTION
as part of tools migration, updating sidekick link. currently, we aren't redirecting, so opening as draft for now.

https://tools.aem.live/tools/project-admin/index.html should work as is, but probably should be tested/validated a bit before we update links and start redirecting old->new