### PR TITLE
fix: remove obsolete scriptUrl from site store

### DIFF
--- a/src/extension/app/store/site.js
+++ b/src/extension/app/store/site.js
@@ -264,7 +264,6 @@ export class SiteStore {
       specialViews,
       wordSaveDelay,
       transient = false,
-      scriptUrl = 'https://www.hlx.live/tools/sidekick/index.js',
     } = config;
     const publicHost = host && host.startsWith('http') ? new URL(host).host : host;
     const hostPrefix = owner && repo ? `${ref}--${repo}--${owner}` : null;
@@ -302,7 +301,6 @@ export class SiteStore {
 
     this.previewHost = previewHost;
     this.liveHost = liveHost;
-    this.scriptUrl = scriptUrl;
 
     this.innerHost = previewHost || stdInnerHost;
     this.outerHost = liveHost || legacyLiveHost || stdOuterHost;

--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -65,7 +65,6 @@ function removeCacheParam(href = window.location.href) {
         'transient',
         'apiUpgrade',
       ].includes(k)));
-    curatedConfig.scriptUrl = chrome.runtime.getURL('index.js');
 
     if (adminVersion) {
       curatedConfig.adminVersion = adminVersion;

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -104,7 +104,6 @@ describe('Test App Store', () => {
     await testDefaultConfig();
 
     expect(appStore.siteStore.plugins.length).to.eq(9);
-    expect(appStore.siteStore.scriptUrl).to.eq('https://www.hlx.live/tools/sidekick/index.js');
     expect(appStore.siteStore.host).to.eq('www.aemboilerplate.com');
     expect(appStore.siteStore.innerHost).to.eq('custom-preview-host.com');
     expect(appStore.siteStore.liveHost).to.eq('custom-live-host.com');


### PR DESCRIPTION
Fix #757 