### PR TITLE
fix: remove labs.aem.live from trusted origins

### DIFF
--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -117,7 +117,6 @@ function isTrustedOrigin(origin) {
   const TRUSTED_ORIGINS = [
     ADMIN_ORIGIN,
     ADMIN_ORIGIN_NEW,
-    'https://labs.aem.live',
     'https://tools.aem.live',
     'http://localhost:3000',
   ];
@@ -127,7 +126,6 @@ function isTrustedOrigin(origin) {
   }
 
   const TRUSTED_ORIGIN_PATTERNS = [
-    /^https:\/\/[a-z0-9-]+--helix-labs-website--adobe\.aem\.(page|live)$/, // labs
     /^https:\/\/[a-z0-9-]+--helix-tools-website--adobe\.aem\.(page|live)$/, // tools
   ];
 

--- a/src/extension/auth.js
+++ b/src/extension/auth.js
@@ -26,7 +26,7 @@ function getRandomId() {
 /**
  * Sets the x-auth-token header for all requests to the Admin API if project config
  * has an auth token. Also sets the Access-Control-Allow-Origin header for
- * all requests from tools.aem.live and labs.aem.live.
+ * all requests from tools.aem.live.
  * @returns {Promise<void>}
  */
 export async function configureAuthAndCorsHeaders() {
@@ -109,7 +109,7 @@ export async function configureAuthAndCorsHeaders() {
           },
           condition: {
             regexFilter,
-            initiatorDomains: ['tools.aem.live', 'labs.aem.live'],
+            initiatorDomains: ['tools.aem.live'],
             requestMethods: ['get'],
             resourceTypes: ['xmlhttprequest'],
           },

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -157,7 +157,7 @@ describe('Test actions', () => {
     resp = await externalActions.getAuthInfo({}, { tab: mockTab('https://tools.aem.live/test') });
     expect(resp).to.deep.equal(['foo']);
 
-    resp = await externalActions.getAuthInfo({}, { tab: mockTab('https://feature--helix-labs-website--adobe.aem.page/feature') });
+    resp = await externalActions.getAuthInfo({}, { tab: mockTab('https://feature--helix-tools-website--adobe.aem.page/feature') });
     expect(resp).to.deep.equal(['foo']);
 
     // untrusted actors
@@ -219,10 +219,7 @@ describe('Test actions', () => {
     resp = await externalActions.getSites({}, { tab: mockTab('https://tools.aem.live/foo') });
     expect(resp).to.deep.equal(expectedOutput);
 
-    resp = await externalActions.getSites({}, { tab: mockTab('https://labs.aem.live/foo') });
-    expect(resp).to.deep.equal(expectedOutput);
-
-    resp = await externalActions.getSites({}, { tab: mockTab('https://feature--helix-labs-website--adobe.aem.page/feature') });
+    resp = await externalActions.getSites({}, { tab: mockTab('https://feature--helix-tools-website--adobe.aem.page/feature') });
     expect(resp).to.deep.equal(expectedOutput);
 
     // untrusted actors

--- a/test/app/components/plugin/plugin.test.js
+++ b/test/app/components/plugin/plugin.test.js
@@ -56,7 +56,7 @@ const TEST_POPOVER_CONFIG = {
   title: 'Test Popover',
   isPopover: true,
   popoverRect: 'width: 100px; height: 100px;',
-  url: 'https://labs.aem.live/tools/snapshot-admin/palette.html?foo=bar&theme=dark',
+  url: 'https://tools.aem.live/tools/snapshot-admin/palette.html?foo=bar&theme=dark',
   passConfig: false,
   passReferrer: false,
   button: {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -164,7 +164,6 @@ describe('Test auth', () => {
             regexFilter: '^https://[0-9a-z-]+--[0-9a-z-]+--test\\.aem\\.(page|live|reviews)/.*',
             initiatorDomains: [
               'tools.aem.live',
-              'labs.aem.live',
             ],
             requestMethods: [
               'get',
@@ -278,7 +277,6 @@ describe('Test auth', () => {
             regexFilter: '^https://[0-9a-z-]+--[0-9a-z-]+--test\\.aem\\.(page|live|reviews)/.*',
             initiatorDomains: [
               'tools.aem.live',
-              'labs.aem.live',
             ],
             requestMethods: [
               'get',
@@ -305,7 +303,6 @@ describe('Test auth', () => {
             regexFilter: '^https://production-host.com/.*',
             initiatorDomains: [
               'tools.aem.live',
-              'labs.aem.live',
             ],
             requestMethods: [
               'get',
@@ -332,7 +329,6 @@ describe('Test auth', () => {
             regexFilter: '^https://custom-preview.com/.*',
             initiatorDomains: [
               'tools.aem.live',
-              'labs.aem.live',
             ],
             requestMethods: [
               'get',
@@ -359,7 +355,6 @@ describe('Test auth', () => {
             regexFilter: '^https://custom-live.com/.*',
             initiatorDomains: [
               'tools.aem.live',
-              'labs.aem.live',
             ],
             requestMethods: [
               'get',
@@ -467,7 +462,6 @@ describe('Test auth', () => {
             regexFilter: '^https://[0-9a-z-]+--[0-9a-z-]+--test\\.aem\\.(page|live|reviews)/.*',
             initiatorDomains: [
               'tools.aem.live',
-              'labs.aem.live',
             ],
             requestMethods: [
               'get',


### PR DESCRIPTION
Fix #758 