### PR TITLE
fix: filter undefined projects

### DIFF
--- a/src/extension/project.js
+++ b/src/extension/project.js
@@ -353,8 +353,7 @@ export async function deleteProject(project) {
     ({ owner, repo } = project);
     handle = `${owner}/${repo}`;
   }
-  const projects = await getConfig('sync', 'projects')
-    || await getConfig('sync', 'hlxSidekickProjects') || []; // legacy
+  const projects = await getConfig('sync', 'projects') || [];
   const i = projects.indexOf(handle);
   if (i >= 0) {
     // delete admin auth header rule

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -132,7 +132,6 @@ describe('Test project', () => {
       let value;
       switch (prop) {
         case 'projects':
-        case 'hlxSidekickProjects': // legacy
           value = ['foo/bar1'];
           break;
         case 'foo/bar1':
@@ -155,20 +154,7 @@ describe('Test project', () => {
     sandbox.restore();
     sandbox.stub(chrome.storage.sync, 'get')
       .withArgs('projects')
-      .resolves({})
-      .withArgs('hlxSidekickProjects')
       .resolves({});
-    projects = await getProjects();
-    expect(projects.length).to.equal(0);
-    // legacy projects
-    sandbox.restore();
-    sandbox.stub(chrome.storage.sync, 'get')
-      .withArgs('projects')
-      .resolves({})
-      .withArgs('hlxSidekickProjects')
-      .resolves({
-        hlxSidekickProjects: ['foo/bar1'],
-      });
     projects = await getProjects();
     expect(projects.length).to.equal(0);
   });


### PR DESCRIPTION
My sidekick ended up in a weird state: it does not open at all (any project).

Service worker error:

```
[WARN] checkTab: error checking tab 1835922453 TypeError: Cannot read properties of undefined (reading 'mountpoints')
    at url-cache.js:32:20
    at Array.find (<anonymous>)
    at isSharePointHost (url-cache.js:31:19)
    at UrlCache.set (url-cache.js:223:24)
    at async checkTab (tab.js:63:5)
```

Root cause analysis: 

`chrome.storage.sync.get('projects')` contains projects for which no `chrome.storage.sync.get(org/repo)` exists.
`getConfig` can return `undefined` but it is not considered in the rest of the code. Then the `projects` array contains `undefined` which are accessed by the url cache.

Flushing my config is clean solution but making the code more robust also does not hurt.