### PR TITLE
fix(regression): isValidProject can throw if project is null

### DIFF
--- a/src/extension/project.js
+++ b/src/extension/project.js
@@ -89,7 +89,8 @@ export async function updateProject(project) {
  * @param {Object} config The project config
  * @returns {boolean} true if valid project config, else false
  */
-export function isValidProject({ owner, repo, ref } = {}) {
+export function isValidProject(config) {
+  const { owner, repo, ref } = config || {};
   return !!(owner && repo && ref);
 }
 

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -409,6 +409,7 @@ describe('Test project', () => {
     expect(isValidProject({ owner: 'foo', repo: 'bar' })).to.be.false;
     expect(isValidProject({ owner: 'foo' })).to.be.false;
     expect(isValidProject()).to.be.false;
+    expect(isValidProject(null)).to.be.false;
   });
 
   it('getProjectMatches', async () => {


### PR DESCRIPTION
## Summary
- `isValidProject()` throws when called with `null` because the default parameter `= {}` only applies to `undefined`, not `null`
- This was introduced in #844 where `getStoredProject` can return `null` from the content script
- Error from extension log:
  ```
  Uncaught (in promise) TypeError: Cannot destructure property 'owner' of '(intermediate value)(intermediate value)(intermediate value)' as it is null.
  ```
- Fix: destructure inside the function body with a `null` guard instead of relying on the default parameter

## Test plan
- [ ] Verify lint passes
- [ ] Verify all tests pass
- [ ] Open extension on a page with no matching project config and confirm no error in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)