### PR TITLE
chore: add AEM_NOT_PRIMARY_CONTENT error template

### DIFF
--- a/src/extension/_locales/de/messages.json
+++ b/src/extension/_locales/de/messages.json
@@ -66,7 +66,7 @@
     "message": "Vorschau von $1 nicht möglich: $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "Inhaltsvorgänge sind auf die primäre Site beschränkt."
+    "message": "Inhaltsaktualisierungen sind auf die primäre Site beschränkt."
   },
   "activate": {
     "message": "Aktivieren"

--- a/src/extension/_locales/de/messages.json
+++ b/src/extension/_locales/de/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "Vorschau von $1 nicht möglich: $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "Inhaltsvorgänge sind auf die primäre Site beschränkt."
+  },
   "activate": {
     "message": "Aktivieren"
   },

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -768,5 +768,8 @@
     },
     "AEM_BACKEND_CONFIG_NOT_SUPPORTED": {
       "message": "This site is now managed in the configuration service."
+    },
+    "AEM_NOT_PRIMARY_CONTENT": {
+      "message": "Content operations are restricted to the primary site."
     }
 }

--- a/src/extension/_locales/en/messages.json
+++ b/src/extension/_locales/en/messages.json
@@ -770,6 +770,6 @@
       "message": "This site is now managed in the configuration service."
     },
     "AEM_NOT_PRIMARY_CONTENT": {
-      "message": "Content operations are restricted to the primary site."
+      "message": "Content updates are restricted to the primary site."
     }
 }

--- a/src/extension/_locales/es/messages.json
+++ b/src/extension/_locales/es/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "No se puede previsualizar $1: $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "Las operaciones de contenido están restringidas al sitio principal."
+  },
   "activate": {
     "message": "Activar"
   },

--- a/src/extension/_locales/es/messages.json
+++ b/src/extension/_locales/es/messages.json
@@ -66,7 +66,7 @@
     "message": "No se puede previsualizar $1: $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "Las operaciones de contenido están restringidas al sitio principal."
+    "message": "Las actualizaciones de contenido están restringidas al sitio principal."
   },
   "activate": {
     "message": "Activar"

--- a/src/extension/_locales/fr/messages.json
+++ b/src/extension/_locales/fr/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "Impossible de prévisualiser $1 : $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "Les opérations de contenu sont limitées au site principal."
+  },
   "activate": {
     "message": "Activer"
   },

--- a/src/extension/_locales/fr/messages.json
+++ b/src/extension/_locales/fr/messages.json
@@ -66,7 +66,7 @@
     "message": "Impossible de prévisualiser $1 : $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "Les opérations de contenu sont limitées au site principal."
+    "message": "Les mises à jour de contenu sont limitées au site principal."
   },
   "activate": {
     "message": "Activer"

--- a/src/extension/_locales/it/messages.json
+++ b/src/extension/_locales/it/messages.json
@@ -66,7 +66,7 @@
     "message": "Impossibile visualizzare in anteprima $1: $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "Le operazioni sui contenuti sono limitate al sito principale."
+    "message": "Gli aggiornamenti dei contenuti sono limitati al sito principale."
   },
   "activate": {
     "message": "Attiva"

--- a/src/extension/_locales/it/messages.json
+++ b/src/extension/_locales/it/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "Impossibile visualizzare in anteprima $1: $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "Le operazioni sui contenuti sono limitate al sito principale."
+  },
   "activate": {
     "message": "Attiva"
   },

--- a/src/extension/_locales/ja/messages.json
+++ b/src/extension/_locales/ja/messages.json
@@ -66,7 +66,7 @@
     "message": "$1 をプレビューできません : $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "コンテンツ操作はプライマリサイトに制限されています。"
+    "message": "コンテンツの更新はプライマリサイトに制限されています。"
   },
   "activate": {
     "message": "アクティベート"

--- a/src/extension/_locales/ja/messages.json
+++ b/src/extension/_locales/ja/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "$1 をプレビューできません : $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "コンテンツ操作はプライマリサイトに制限されています。"
+  },
   "activate": {
     "message": "アクティベート"
   },

--- a/src/extension/_locales/ko/messages.json
+++ b/src/extension/_locales/ko/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "$1 미리보기 불가: $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "콘텐츠 작업은 기본 사이트로 제한됩니다."
+  },
   "activate": {
     "message": "활성화"
   },

--- a/src/extension/_locales/ko/messages.json
+++ b/src/extension/_locales/ko/messages.json
@@ -66,7 +66,7 @@
     "message": "$1 미리보기 불가: $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "콘텐츠 작업은 기본 사이트로 제한됩니다."
+    "message": "콘텐츠 업데이트는 기본 사이트로 제한됩니다."
   },
   "activate": {
     "message": "활성화"

--- a/src/extension/_locales/pt_BR/messages.json
+++ b/src/extension/_locales/pt_BR/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "Não é possível visualizar $1: $2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "As operações de conteúdo estão restritas ao site principal."
+  },
   "activate": {
     "message": "Ativar"
   },

--- a/src/extension/_locales/pt_BR/messages.json
+++ b/src/extension/_locales/pt_BR/messages.json
@@ -66,7 +66,7 @@
     "message": "Não é possível visualizar $1: $2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "As operações de conteúdo estão restritas ao site principal."
+    "message": "As atualizações de conteúdo estão restritas ao site principal."
   },
   "activate": {
     "message": "Ativar"

--- a/src/extension/_locales/zh_CN/messages.json
+++ b/src/extension/_locales/zh_CN/messages.json
@@ -66,7 +66,7 @@
     "message": "无法预览 $1：$2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "内容操作仅限于主站点。"
+    "message": "内容更新仅限于主站点。"
   },
   "activate": {
     "message": "激活"

--- a/src/extension/_locales/zh_CN/messages.json
+++ b/src/extension/_locales/zh_CN/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "无法预览 $1：$2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "内容操作仅限于主站点。"
+  },
   "activate": {
     "message": "激活"
   },

--- a/src/extension/_locales/zh_TW/messages.json
+++ b/src/extension/_locales/zh_TW/messages.json
@@ -66,7 +66,7 @@
     "message": "無法預覽 $1：$2"
   },
   "AEM_NOT_PRIMARY_CONTENT": {
-    "message": "內容操作僅限於主要網站。"
+    "message": "內容更新僅限於主要網站。"
   },
   "activate": {
     "message": "啟動"

--- a/src/extension/_locales/zh_TW/messages.json
+++ b/src/extension/_locales/zh_TW/messages.json
@@ -65,6 +65,9 @@
   "AEM_BACKEND_VALIDATION_FAILED": {
     "message": "無法預覽 $1：$2"
   },
+  "AEM_NOT_PRIMARY_CONTENT": {
+    "message": "內容操作僅限於主要網站。"
+  },
   "activate": {
     "message": "啟動"
   },

--- a/src/extension/app/constants.js
+++ b/src/extension/app/constants.js
@@ -476,4 +476,10 @@ export const ERRORS = [
     code: 'AEM_BACKEND_CONFIG_NOT_SUPPORTED',
     template: 'File based config no longer supported: $1',
   },
+
+  // content errors
+  {
+    code: 'AEM_NOT_PRIMARY_CONTENT',
+    template: 'Content operations restricted to the primary site: $1',
+  },
 ];

--- a/test/app/utils/admin-client.test.js
+++ b/test/app/utils/admin-client.test.js
@@ -656,7 +656,7 @@ describe('Test Admin Client', () => {
         'Content operations restricted to the primary site: org/site',
         'AEM_NOT_PRIMARY_CONTENT',
       );
-      expect(res).to.equal('(403) Content operations are restricted to the primary site.');
+      expect(res).to.equal('(403) Content updates are restricted to the primary site.');
       expect(details).to.equal('org/site');
     });
 

--- a/test/app/utils/admin-client.test.js
+++ b/test/app/utils/admin-client.test.js
@@ -648,6 +648,18 @@ describe('Test Admin Client', () => {
       expect(details).to.equal('MP4 is larger than 36MB: 41MB');
     });
 
+    it('should return localized error for non-primary content', () => {
+      const [res, details] = adminClient.getLocalizedError(
+        'preview',
+        path,
+        403,
+        'Content operations restricted to the primary site: org/site',
+        'AEM_NOT_PRIMARY_CONTENT',
+      );
+      expect(res).to.equal('(403) Content operations are restricted to the primary site.');
+      expect(details).to.equal('org/site');
+    });
+
     it('should return localized error for 401 on bulk operation', () => {
       path = '/*';
       const [res] = adminClient.getLocalizedError('publish', path, 401);


### PR DESCRIPTION
## Summary
- Add `AEM_NOT_PRIMARY_CONTENT` error template to handle 403 responses when content operations are attempted on a non-primary site (see [helix-admin#3583](https://github.com/adobe/helix-admin/pull/3583))

🤖 Generated with [Claude Code](https://claude.com/claude-code)