### PR TITLE
feat: add auth token rule for scheduler tool

### DIFF
--- a/src/extension/auth.js
+++ b/src/extension/auth.js
@@ -23,6 +23,10 @@ const TOOLS_AUTH_TOKEN_RULES = [
     requestDomain: 'helix-json2html.adobeaem.workers.dev',
     regexFilter: (owner, repo) => `/((config|api)/)?${owner}/${repo}/[^/?#]+(?:/.*)?(?:\\?.*)?$`,
   },
+  {
+    requestDomain: 'helix-snapshot-scheduler-prod.adobeaem.workers.dev',
+    regexFilter: (owner, repo) => `/(register|schedule(?:/(?:page|snapshot))?)/${owner}/${repo}(?:/[^?#]*)?(?:\\?.*)?$`,
+  },
 ];
 
 const TOOLS_SITE_TOKEN_RULES = [

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -29,23 +29,42 @@ import { error } from './test-utils.js';
 window.chrome = chromeMock;
 
 function createExpectedAuthToolsRules(authToken, owner = 'test', repo = 'site') {
+  const action = {
+    type: 'modifyHeaders',
+    requestHeaders: [
+      {
+        operation: 'set',
+        header: 'x-auth-token',
+        value: authToken,
+      },
+    ],
+  };
   return [{
     id: sinon.match.number,
     priority: 1,
-    action: {
-      type: 'modifyHeaders',
-      requestHeaders: [
-        {
-          operation: 'set',
-          header: 'x-auth-token',
-          value: authToken,
-        },
-      ],
-    },
+    action,
     condition: {
       initiatorDomains: ['tools.aem.live'],
       regexFilter: `/((config|api)/)?${owner}/${repo}/[^/?#]+(?:/.*)?(?:\\?.*)?$`,
       requestDomains: ['helix-json2html.adobeaem.workers.dev'],
+      requestMethods: [
+        'get',
+        'put',
+        'post',
+        'delete',
+      ],
+      resourceTypes: [
+        'xmlhttprequest',
+      ],
+    },
+  }, {
+    id: sinon.match.number,
+    priority: 1,
+    action,
+    condition: {
+      initiatorDomains: ['tools.aem.live'],
+      regexFilter: `/(register|schedule(?:/(?:page|snapshot))?)/${owner}/${repo}(?:/[^?#]*)?(?:\\?.*)?$`,
+      requestDomains: ['helix-snapshot-scheduler-prod.adobeaem.workers.dev'],
       requestMethods: [
         'get',
         'put',


### PR DESCRIPTION
## Summary

Adds a `declarativeNetRequest` auth-token rule so the sidekick injects the project's `x-auth-token` for calls the snapshot scheduler tool makes to `helix-snapshot-scheduler-prod.adobeaem.workers.dev`.

- New entry in `TOOLS_AUTH_TOKEN_RULES` for the scheduler worker domain.
- Tight, fully project-scoped `regexFilter` covering all scheduler endpoints, each of which carries `{org}/{site}` in the path:
  - `register/{org}/{site}` (GET registration check + POST register)
  - `schedule/{org}/{site}` (GET schedule)
  - `schedule/page/{org}/{site}[/path]` (POST schedule + DELETE page)
  - `schedule/snapshot/{org}/{site}/{id}` (DELETE snapshot)
- `{owner}/{repo}` is anchored right after a known prefix and the regex ends at `$`, so the token is only injected for the current project and never leaks to unrelated paths on that worker.

## Test plan

- [x] `npx eslint src/extension/auth.js test/auth.test.js` passes
- [x] `npx wtr ./test/auth.test.js` — all auth tests pass, `auth.js` at 100% statements/branches/functions/lines
- [ ] Full suite `npm run test` green in CI
- [ ] Manual: scheduler tool at tools.aem.live successfully authenticates against the worker for a project the user is signed into

Made with [Cursor](https://cursor.com)