### PR TITLE
fix(status): use extensionless paths in admin requests for documents

### DIFF
--- a/src/extension/app/store/app.js
+++ b/src/extension/app/store/app.js
@@ -968,7 +968,7 @@ export class AppStore {
     this.setState(STATE.FETCHING_STATUS);
     const isDM = this.isEditor() || this.isAdmin();
     const editUrl = isDM ? this.location.href : (fetchEdit ? 'auto' : '');
-    const path = isDM ? '/' : this.location.pathname;
+    const path = isDM ? '/' : this.location.pathname.replace(/\.html$/, '');
 
     status = await this.api.getStatus(path, editUrl);
 

--- a/test/app/store/app.test.js
+++ b/test/app/store/app.test.js
@@ -448,6 +448,26 @@ describe('Test App Store', () => {
       expect(appStore.status.webPath).to.equal('/');
     });
 
+    it('strips trailing .html extension from document paths', async () => {
+      sidekickTest
+        .mockFetchStatusSuccess();
+      await instance.loadContext(sidekickElement, defaultSidekickConfig);
+      sidekickTest.sandbox.stub(instance, 'isEditor').returns(false);
+      sidekickTest.sandbox.stub(instance, 'isAdmin').returns(false);
+      const getStatusStub = sidekickTest.sandbox
+        .stub(instance.api, 'getStatus')
+        .resolves({ webPath: '/foo' });
+
+      instance.location.pathname = '/foo.html';
+      await instance.fetchStatus();
+      expect(getStatusStub.calledWith('/foo')).to.be.true;
+
+      // non-document extensions are left untouched
+      instance.location.pathname = '/data.json';
+      await instance.fetchStatus();
+      expect(getStatusStub.calledWith('/data.json')).to.be.true;
+    });
+
     it('unauthorized', async () => {
       sidekickTest
         .mockFetchStatusUnauthorized();


### PR DESCRIPTION
Fix #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)