### PR TITLE
fix(cache-buster): escape all regex metacharacters in domain filter

### DIFF
--- a/src/extension/cache-buster.js
+++ b/src/extension/cache-buster.js
@@ -38,7 +38,12 @@ export async function addCacheBusterRule(domain) {
     log.warn('addCacheBusterRule: no domain');
     return false;
   }
-  const escapedDomain = domain.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const trimmedDomain = domain.trim();
+  if (/[*+?^${}()|[\]\\]/.test(trimmedDomain)) {
+    log.warn('addCacheBusterRule: invalid domain');
+    return false;
+  }
+  const escapedDomain = trimmedDomain.replaceAll(/\./g, '\\.');
 
   const ruleId = Math.floor(Math.random() * 1000000);
   /** @type {chrome.declarativeNetRequest.Rule[]} */

--- a/src/extension/cache-buster.js
+++ b/src/extension/cache-buster.js
@@ -38,7 +38,7 @@ export async function addCacheBusterRule(domain) {
     log.warn('addCacheBusterRule: no domain');
     return false;
   }
-  const escapedDomain = domain.trim().replaceAll(/\./g, '\\.');
+  const escapedDomain = domain.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   const ruleId = Math.floor(Math.random() * 1000000);
   /** @type {chrome.declarativeNetRequest.Rule[]} */

--- a/src/extension/cache-buster.js
+++ b/src/extension/cache-buster.js
@@ -39,7 +39,7 @@ export async function addCacheBusterRule(domain) {
     return false;
   }
   const trimmedDomain = domain.trim();
-  if (/[*+?^${}()|[\]\\]/.test(trimmedDomain)) {
+  if (/[^a-zA-Z0-9.-]/.test(trimmedDomain)) {
     log.warn('addCacheBusterRule: invalid domain');
     return false;
   }

--- a/test/cache-buster.test.js
+++ b/test/cache-buster.test.js
@@ -115,13 +115,14 @@ describe('cache-buster', () => {
       })).to.be.true;
     });
 
-    it('escapes regex metacharacters in the domain so they are matched literally', async () => {
+    it('returns false and warns when domain contains regex metacharacters', async () => {
+      const logWarn = sandbox.stub(log, 'warn');
       const updateSessionRules = sandbox.stub(chrome.declarativeNetRequest, 'updateSessionRules').resolves();
 
-      await addCacheBusterRule('(.*)');
-
-      const rule = updateSessionRules.firstCall.args[0].addRules[0];
-      expect(rule.condition.regexFilter).to.equal('^https://\\(\\.\\*\\)/.*');
+      expect(await addCacheBusterRule('(.*)')).to.equal(false);
+      expect(await addCacheBusterRule('evil[a-z].com')).to.equal(false);
+      expect(updateSessionRules.notCalled).to.be.true;
+      expect(logWarn.calledWith('addCacheBusterRule: invalid domain')).to.be.true;
     });
 
     it('accepts full URL and uses hostname', async () => {

--- a/test/cache-buster.test.js
+++ b/test/cache-buster.test.js
@@ -121,6 +121,7 @@ describe('cache-buster', () => {
 
       expect(await addCacheBusterRule('(.*)')).to.equal(false);
       expect(await addCacheBusterRule('evil[a-z].com')).to.equal(false);
+      expect(await addCacheBusterRule('under_score.com')).to.equal(false);
       expect(updateSessionRules.notCalled).to.be.true;
       expect(logWarn.calledWith('addCacheBusterRule: invalid domain')).to.be.true;
     });

--- a/test/cache-buster.test.js
+++ b/test/cache-buster.test.js
@@ -115,6 +115,15 @@ describe('cache-buster', () => {
       })).to.be.true;
     });
 
+    it('escapes regex metacharacters in the domain so they are matched literally', async () => {
+      const updateSessionRules = sandbox.stub(chrome.declarativeNetRequest, 'updateSessionRules').resolves();
+
+      await addCacheBusterRule('(.*)');
+
+      const rule = updateSessionRules.firstCall.args[0].addRules[0];
+      expect(rule.condition.regexFilter).to.equal('^https://\\(\\.\\*\\)/.*');
+    });
+
     it('accepts full URL and uses hostname', async () => {
       const updateSessionRules = sandbox.stub(chrome.declarativeNetRequest, 'updateSessionRules').resolves();
 


### PR DESCRIPTION
Fix #879

🤖 Generated with Claude Code